### PR TITLE
Add bypass-rehide-blocks config option

### DIFF
--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/antixray/ChunkPacketBlockControllerAntiXray.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/antixray/ChunkPacketBlockControllerAntiXray.java
@@ -70,14 +70,22 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
     private final boolean[] obfuscateGlobal = new boolean[Block.BLOCK_STATE_REGISTRY.size()];
     private final boolean[] traceGlobal;
     private final boolean[] blockEntityGlobal = new boolean[Block.BLOCK_STATE_REGISTRY.size()];
-    private final LevelChunkSection[] emptyNearbyChunkSections = { EMPTY_SECTION, EMPTY_SECTION, EMPTY_SECTION,
-            EMPTY_SECTION };
+    private final LevelChunkSection[] emptyNearbyChunkSections = {EMPTY_SECTION, EMPTY_SECTION, EMPTY_SECTION, EMPTY_SECTION};
     private final int maxBlockHeightUpdatePosition;
 
-    public ChunkPacketBlockControllerAntiXray(RayTraceAntiXray plugin, ChunkPacketBlockController oldController,
-            boolean rayTraceThirdPerson, double rayTraceDistance, boolean rehideBlocks, double rehideDistance,
-            int maxRayTraceBlockCountPerChunk, Iterable<? extends String> toTrace,
-            Iterable<? extends String> bypassRehideBlocks, Level level, Executor executor) {
+    public ChunkPacketBlockControllerAntiXray(
+            RayTraceAntiXray plugin,
+            ChunkPacketBlockController oldController,
+            boolean rayTraceThirdPerson,
+            double rayTraceDistance,
+            boolean rehideBlocks,
+            double rehideDistance,
+            int maxRayTraceBlockCountPerChunk,
+            Iterable<? extends String> toTrace,
+            Iterable<? extends String> bypassRehideBlocks,
+            Level level,
+            Executor executor
+    ) {
         this.plugin = plugin;
         this.oldController = oldController;
         this.executor = executor;
@@ -97,10 +105,10 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             toObfuscate = paperWorldConfig.hiddenBlocks;
             presetBlockStates = null;
             presetBlockStatesFull = null;
-            presetBlockStatesStone = new BlockState[] { Blocks.STONE.defaultBlockState() };
-            presetBlockStatesDeepslate = new BlockState[] { Blocks.DEEPSLATE.defaultBlockState() };
-            presetBlockStatesNetherrack = new BlockState[] { Blocks.NETHERRACK.defaultBlockState() };
-            presetBlockStatesEndStone = new BlockState[] { Blocks.END_STONE.defaultBlockState() };
+            presetBlockStatesStone = new BlockState[]{Blocks.STONE.defaultBlockState()};
+            presetBlockStatesDeepslate = new BlockState[]{Blocks.DEEPSLATE.defaultBlockState()};
+            presetBlockStatesNetherrack = new BlockState[]{Blocks.NETHERRACK.defaultBlockState()};
+            presetBlockStatesEndStone = new BlockState[]{Blocks.END_STONE.defaultBlockState()};
             presetBlockStateBitsGlobal = null;
             presetBlockStateBitsStoneGlobal = new int[]{GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.STONE.defaultBlockState(), PaletteResize.noResizeExpected())};
             presetBlockStateBitsDeepslateGlobal = new int[]{GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.DEEPSLATE.defaultBlockState(), PaletteResize.noResizeExpected())};
@@ -118,19 +126,12 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                 }
             }
 
-            // The doc of the LinkedHashSet(Collection<? extends E>) constructor doesn't
-            // specify that the insertion order is the predictable iteration order of the
-            // specified Collection, although it is in the implementation
+            // The doc of the LinkedHashSet(Collection<? extends E>) constructor doesn't specify that the insertion order is the predictable iteration order of the specified Collection, although it is in the implementation
             Set<BlockState> presetBlockStateSet = new LinkedHashSet<>();
-            // Therefore addAll(Collection<? extends E>) is used, which guarantees this
-            // order in the doc
+            // Therefore addAll(Collection<? extends E>) is used, which guarantees this order in the doc
             presetBlockStateSet.addAll(presetBlockStateList);
-            presetBlockStates = presetBlockStateSet.isEmpty()
-                    ? new BlockState[] { Blocks.DIAMOND_ORE.defaultBlockState() }
-                    : presetBlockStateSet.toArray(new BlockState[0]);
-            presetBlockStatesFull = presetBlockStateSet.isEmpty()
-                    ? new BlockState[] { Blocks.DIAMOND_ORE.defaultBlockState() }
-                    : presetBlockStateList.toArray(new BlockState[0]);
+            presetBlockStates = presetBlockStateSet.isEmpty() ? new BlockState[]{Blocks.DIAMOND_ORE.defaultBlockState()} : presetBlockStateSet.toArray(new BlockState[0]);
+            presetBlockStatesFull = presetBlockStateSet.isEmpty() ? new BlockState[]{Blocks.DIAMOND_ORE.defaultBlockState()} : presetBlockStateList.toArray(new BlockState[0]);
             presetBlockStatesStone = null;
             presetBlockStatesDeepslate = null;
             presetBlockStatesNetherrack = null;
@@ -149,8 +150,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
 
         for (Block block : toObfuscate) {
 
-            // Don't obfuscate air because air causes unnecessary block updates and causes
-            // block updates to fail in the void
+            // Don't obfuscate air because air causes unnecessary block updates and causes block updates to fail in the void
             if (block != null && !block.defaultBlockState().isAir()) {
                 // Replace all block states of a specified block
                 for (BlockState blockState : block.getStateDefinition().getPossibleStates()) {
@@ -173,8 +173,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                     e.printStackTrace();
                 }
 
-                // Don't obfuscate air because air causes unnecessary block updates and causes
-                // block updates to fail in the void
+                // Don't obfuscate air because air causes unnecessary block updates and causes block updates to fail in the void
                 if (block != null && !block.defaultBlockState().isAir()) {
                     // Replace all block states of a specified block
                     for (BlockState blockState : block.getStateDefinition().getPossibleStates()) {
@@ -234,8 +233,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
 
     @Override
     public BlockState[] getPresetBlockStates(Level level, ChunkPos chunkPos, int chunkSectionY) {
-        // Return the block states to be added to the paletted containers so that they
-        // can be used for obfuscation
+        // Return the block states to be added to the paletted containers so that they can be used for obfuscation
         int bottomBlockY = chunkSectionY << 4;
 
         if (bottomBlockY < maxBlockHeight) {
@@ -262,16 +260,13 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
     }
 
     @Override
-    public ChunkPacketInfoAntiXray getChunkPacketInfo(ClientboundLevelChunkWithLightPacket chunkPacket,
-            LevelChunk chunk) {
-        // Return a new instance to collect data and objects in the right state while
-        // creating the chunk packet for thread safe access later
+    public ChunkPacketInfoAntiXray getChunkPacketInfo(ClientboundLevelChunkWithLightPacket chunkPacket, LevelChunk chunk) {
+        // Return a new instance to collect data and objects in the right state while creating the chunk packet for thread safe access later
         return new ChunkPacketInfoAntiXray(chunkPacket, chunk, this);
     }
 
     @Override
-    public void modifyBlocks(ClientboundLevelChunkWithLightPacket chunkPacket,
-            ChunkPacketInfo<BlockState> chunkPacketInfo) {
+    public void modifyBlocks(ClientboundLevelChunkWithLightPacket chunkPacket, ChunkPacketInfo<BlockState> chunkPacketInfo) {
         if (!(chunkPacketInfo instanceof ChunkPacketInfoAntiXray)) {
             chunkPacket.setReady(true);
             return;
@@ -286,39 +281,29 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                     plugin,
                     chunk.getLevel().getWorld(),
                     x, z,
-                    () -> modifyBlocks(chunkPacket, chunkPacketInfo));
+                    () -> modifyBlocks(chunkPacket, chunkPacketInfo)
+            );
             return;
         }
 
         Level level = chunk.getLevel();
-        ((ChunkPacketInfoAntiXray) chunkPacketInfo).setNearbyChunks(level.getChunkIfLoaded(x - 1, z),
-                level.getChunkIfLoaded(x + 1, z), level.getChunkIfLoaded(x, z - 1), level.getChunkIfLoaded(x, z + 1));
+        ((ChunkPacketInfoAntiXray) chunkPacketInfo).setNearbyChunks(level.getChunkIfLoaded(x - 1, z), level.getChunkIfLoaded(x + 1, z), level.getChunkIfLoaded(x, z - 1), level.getChunkIfLoaded(x, z + 1));
         executor.execute((Runnable) chunkPacketInfo);
     }
 
-    // Actually these fields should be variables inside the obfuscate method but in
-    // sync mode or with SingleThreadExecutor in async mode it's okay (even without
-    // ThreadLocal)
-    // If an ExecutorService with multiple threads is used, ThreadLocal must be used
-    // here
-    private final ThreadLocal<int[]> presetBlockStateBits = ThreadLocal
-            .withInitial(() -> new int[getPresetBlockStatesFullLength()]);
-    private static final ThreadLocal<boolean[]> SOLID = ThreadLocal
-            .withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
-    private static final ThreadLocal<boolean[]> OBFUSCATE = ThreadLocal
-            .withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
-    private static final ThreadLocal<boolean[]> TRACE = ThreadLocal
-            .withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
-    private static final ThreadLocal<boolean[]> BLOCK_ENTITY = ThreadLocal
-            .withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
-    // These boolean arrays represent chunk layers, true means don't obfuscate,
-    // false means obfuscate
+    // Actually these fields should be variables inside the obfuscate method but in sync mode or with SingleThreadExecutor in async mode it's okay (even without ThreadLocal)
+    // If an ExecutorService with multiple threads is used, ThreadLocal must be used here
+    private final ThreadLocal<int[]> presetBlockStateBits = ThreadLocal.withInitial(() -> new int[getPresetBlockStatesFullLength()]);
+    private static final ThreadLocal<boolean[]> SOLID = ThreadLocal.withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
+    private static final ThreadLocal<boolean[]> OBFUSCATE = ThreadLocal.withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
+    private static final ThreadLocal<boolean[]> TRACE = ThreadLocal.withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
+    private static final ThreadLocal<boolean[]> BLOCK_ENTITY = ThreadLocal.withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
+    // These boolean arrays represent chunk layers, true means don't obfuscate, false means obfuscate
     private static final ThreadLocal<boolean[][]> CURRENT = ThreadLocal.withInitial(() -> new boolean[16][16]);
     private static final ThreadLocal<boolean[][]> NEXT = ThreadLocal.withInitial(() -> new boolean[16][16]);
     private static final ThreadLocal<boolean[][]> NEXT_NEXT = ThreadLocal.withInitial(() -> new boolean[16][16]);
     private static final ThreadLocal<boolean[][]> TRACE_CACHE = ThreadLocal.withInitial(() -> new boolean[16][16]);
-    private static final ThreadLocal<boolean[][]> BLOCK_ENTITY_CACHE = ThreadLocal
-            .withInitial(() -> new boolean[16][16]);
+    private static final ThreadLocal<boolean[][]> BLOCK_ENTITY_CACHE = ThreadLocal.withInitial(() -> new boolean[16][16]);
     private static final Field BLOCK_ENTITIES_DATA_FIELD;
     private static final Field PACKED_X_Z_FIELD;
     private static final Field Y_FIELD;
@@ -327,8 +312,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         try {
             BLOCK_ENTITIES_DATA_FIELD = ClientboundLevelChunkPacketData.class.getDeclaredField("blockEntitiesData");
             BLOCK_ENTITIES_DATA_FIELD.setAccessible(true);
-            Class<?> blockEntityInfoClass = Class
-                    .forName("net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData$BlockEntityInfo");
+            Class<?> blockEntityInfoClass = Class.forName("net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData$BlockEntityInfo");
             PACKED_X_Z_FIELD = blockEntityInfoClass.getDeclaredField("packedXZ");
             PACKED_X_Z_FIELD.setAccessible(true);
             Y_FIELD = blockEntityInfoClass.getDeclaredField("y");
@@ -349,15 +333,13 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         boolean[][] nextNext = NEXT_NEXT.get();
         boolean[][] traceCache = TRACE_CACHE.get();
         boolean[][] blockEntityCache = BLOCK_ENTITY_CACHE.get();
-        // bitStorageReader, bitStorageWriter and nearbyChunkSections could also be
-        // reused (with ThreadLocal if necessary) but it's not worth it
+        // bitStorageReader, bitStorageWriter and nearbyChunkSections could also be reused (with ThreadLocal if necessary) but it's not worth it
         BitStorageReader bitStorageReader = new BitStorageReader();
         BitStorageWriter bitStorageWriter = new BitStorageWriter();
         LevelChunkSection[] nearbyChunkSections = new LevelChunkSection[4];
         LevelChunk chunk = chunkPacketInfoAntiXray.getChunk();
         Level level = chunk.getLevel();
-        int maxChunkSectionIndex = Math.min((maxBlockHeight >> 4) - chunk.getMinSectionY(), chunk.getSectionsCount())
-                - 1;
+        int maxChunkSectionIndex = Math.min((maxBlockHeight >> 4) - chunk.getMinSectionY(), chunk.getSectionsCount()) - 1;
         boolean[] solidTemp = null;
         boolean[] obfuscateTemp = null;
         boolean[] traceTemp = null;
@@ -365,58 +347,53 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         bitStorageReader.setBuffer(chunkPacketInfoAntiXray.getBuffer());
         bitStorageWriter.setBuffer(chunkPacketInfoAntiXray.getBuffer());
         int numberOfBlocks = presetBlockStateBits.length;
-        // Keep the lambda expressions as simple as possible. They are used very
-        // frequently.
-        LayeredIntSupplier random = numberOfBlocks == 1 ? (() -> 0)
-                : engineMode == EngineMode.OBFUSCATE_LAYER ? new LayeredIntSupplier() {
-                    // engine-mode: 3
-                    private int state;
-                    private int next;
+        // Keep the lambda expressions as simple as possible. They are used very frequently.
+        LayeredIntSupplier random = numberOfBlocks == 1 ? (() -> 0) : engineMode == EngineMode.OBFUSCATE_LAYER ? new LayeredIntSupplier() {
+            // engine-mode: 3
+            private int state;
+            private int next;
 
-                    {
-                        while ((state = ThreadLocalRandom.current().nextInt()) == 0)
-                            ;
-                    }
+            {
+                while ((state = ThreadLocalRandom.current().nextInt()) == 0) ;
+            }
 
-                    @Override
-                    public void nextLayer() {
-                        // https://en.wikipedia.org/wiki/Xorshift
-                        state ^= state << 13;
-                        state ^= state >>> 17;
-                        state ^= state << 5;
-                        // https://www.pcg-random.org/posts/bounded-rands.html
-                        next = (int) ((Integer.toUnsignedLong(state) * numberOfBlocks) >>> 32);
-                    }
+            @Override
+            public void nextLayer() {
+                // https://en.wikipedia.org/wiki/Xorshift
+                state ^= state << 13;
+                state ^= state >>> 17;
+                state ^= state << 5;
+                // https://www.pcg-random.org/posts/bounded-rands.html
+                next = (int) ((Integer.toUnsignedLong(state) * numberOfBlocks) >>> 32);
+            }
 
-                    @Override
-                    public int getAsInt() {
-                        return next;
-                    }
-                } : new LayeredIntSupplier() {
-                    // engine-mode: 2
-                    private int state;
+            @Override
+            public int getAsInt() {
+                return next;
+            }
+        } : new LayeredIntSupplier() {
+            // engine-mode: 2
+            private int state;
 
-                    {
-                        while ((state = ThreadLocalRandom.current().nextInt()) == 0)
-                            ;
-                    }
+            {
+                while ((state = ThreadLocalRandom.current().nextInt()) == 0) ;
+            }
 
-                    @Override
-                    public int getAsInt() {
-                        // https://en.wikipedia.org/wiki/Xorshift
-                        state ^= state << 13;
-                        state ^= state >>> 17;
-                        state ^= state << 5;
-                        // https://www.pcg-random.org/posts/bounded-rands.html
-                        return (int) ((Integer.toUnsignedLong(state) * numberOfBlocks) >>> 32);
-                    }
-                };
+            @Override
+            public int getAsInt() {
+                // https://en.wikipedia.org/wiki/Xorshift
+                state ^= state << 13;
+                state ^= state >>> 17;
+                state ^= state << 5;
+                // https://www.pcg-random.org/posts/bounded-rands.html
+                return (int) ((Integer.toUnsignedLong(state) * numberOfBlocks) >>> 32);
+            }
+        };
         HashMap<BlockPos, Boolean> blocks = new HashMap<>();
         HashSet<BlockPos> blockEntities = new HashSet<>();
 
         for (int chunkSectionIndex = 0; chunkSectionIndex <= maxChunkSectionIndex; chunkSectionIndex++) {
-            if (chunkPacketInfoAntiXray.isWritten(chunkSectionIndex)
-                    && chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex) != null) {
+            if (chunkPacketInfoAntiXray.isWritten(chunkSectionIndex) && chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex) != null) {
                 int[] presetBlockStateBitsTemp;
 
                 if (chunkPacketInfoAntiXray.getPalette(chunkSectionIndex) instanceof GlobalPalette) {
@@ -429,23 +406,18 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                                 presetBlockStateBitsTemp = presetBlockStateBitsEndStoneGlobal;
                                 break;
                             default:
-                                presetBlockStateBitsTemp = chunkSectionIndex + chunk.getMinSectionY() < 0
-                                        ? presetBlockStateBitsDeepslateGlobal
-                                        : presetBlockStateBitsStoneGlobal;
+                                presetBlockStateBitsTemp = chunkSectionIndex + chunk.getMinSectionY() < 0 ? presetBlockStateBitsDeepslateGlobal : presetBlockStateBitsStoneGlobal;
                         }
                     } else {
                         presetBlockStateBitsTemp = presetBlockStateBitsGlobal;
                     }
                 } else {
                     // If it's presetBlockStates, use this.presetBlockStatesFull instead
-                    BlockState[] presetBlockStatesFull = chunkPacketInfoAntiXray
-                            .getPresetValues(chunkSectionIndex) == presetBlockStates ? this.presetBlockStatesFull
-                                    : chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex);
+                    BlockState[] presetBlockStatesFull = chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex) == presetBlockStates ? this.presetBlockStatesFull : chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex);
                     presetBlockStateBitsTemp = presetBlockStateBits;
 
                     for (int i = 0; i < presetBlockStateBitsTemp.length; i++) {
-                        // This is thread safe because we only request IDs that are guaranteed to be in
-                        // the palette and are visible
+                        // This is thread safe because we only request IDs that are guaranteed to be in the palette and are visible
                         // For more details see the comments in the readPalette method
                         presetBlockStateBitsTemp[i] = chunkPacketInfoAntiXray.getPalette(chunkSectionIndex).idFor(presetBlockStatesFull[i], PaletteResize.noResizeExpected());
                     }
@@ -454,22 +426,17 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                 bitStorageWriter.setIndex(chunkPacketInfoAntiXray.getIndex(chunkSectionIndex));
 
                 // Check if the chunk section below was not obfuscated
-                if (chunkSectionIndex == 0 || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex - 1)
-                        || chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex - 1) == null) {
+                if (chunkSectionIndex == 0 || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex - 1) || chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex - 1) == null) {
                     // If so, initialize some stuff
                     bitStorageReader.setBits(chunkPacketInfoAntiXray.getBits(chunkSectionIndex));
                     bitStorageReader.setIndex(chunkPacketInfoAntiXray.getIndex(chunkSectionIndex));
                     solidTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), solid, solidGlobal);
-                    obfuscateTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), obfuscate,
-                            obfuscateGlobal);
-                    traceTemp = trace == obfuscate ? obfuscateTemp
-                            : readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), trace, traceGlobal);
-                    blockEntityTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), blockEntity,
-                            blockEntityGlobal);
+                    obfuscateTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), obfuscate, obfuscateGlobal);
+                    traceTemp = trace == obfuscate ? obfuscateTemp : readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), trace, traceGlobal);
+                    blockEntityTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), blockEntity, blockEntityGlobal);
                     // Read the blocks of the upper layer of the chunk section below if it exists
                     LevelChunkSection belowChunkSection = null;
-                    boolean skipFirstLayer = chunkSectionIndex == 0
-                            || (belowChunkSection = chunk.getSections()[chunkSectionIndex - 1]) == EMPTY_SECTION;
+                    boolean skipFirstLayer = chunkSectionIndex == 0 || (belowChunkSection = chunk.getSections()[chunkSectionIndex - 1]) == EMPTY_SECTION;
 
                     for (int z = 0; z < 16; z++) {
                         for (int x = 0; x < 16; x++) {
@@ -479,24 +446,16 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                         }
                     }
 
-                    // Abuse the obfuscateLayer method to read the blocks of the first layer of the
-                    // current chunk section
+                    // Abuse the obfuscateLayer method to read the blocks of the first layer of the current chunk section
                     bitStorageWriter.setBits(0);
-                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, -1, bitStorageReader,
-                            bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp,
-                            presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache,
-                            emptyNearbyChunkSections, random, blocks, blockEntities);
+                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, -1, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp, presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache, emptyNearbyChunkSections, random, blocks, blockEntities);
                 }
 
                 bitStorageWriter.setBits(chunkPacketInfoAntiXray.getBits(chunkSectionIndex));
-                nearbyChunkSections[0] = chunkPacketInfoAntiXray.getNearbyChunks()[0] == null ? EMPTY_SECTION
-                        : chunkPacketInfoAntiXray.getNearbyChunks()[0].getSections()[chunkSectionIndex];
-                nearbyChunkSections[1] = chunkPacketInfoAntiXray.getNearbyChunks()[1] == null ? EMPTY_SECTION
-                        : chunkPacketInfoAntiXray.getNearbyChunks()[1].getSections()[chunkSectionIndex];
-                nearbyChunkSections[2] = chunkPacketInfoAntiXray.getNearbyChunks()[2] == null ? EMPTY_SECTION
-                        : chunkPacketInfoAntiXray.getNearbyChunks()[2].getSections()[chunkSectionIndex];
-                nearbyChunkSections[3] = chunkPacketInfoAntiXray.getNearbyChunks()[3] == null ? EMPTY_SECTION
-                        : chunkPacketInfoAntiXray.getNearbyChunks()[3].getSections()[chunkSectionIndex];
+                nearbyChunkSections[0] = chunkPacketInfoAntiXray.getNearbyChunks()[0] == null ? EMPTY_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[0].getSections()[chunkSectionIndex];
+                nearbyChunkSections[1] = chunkPacketInfoAntiXray.getNearbyChunks()[1] == null ? EMPTY_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[1].getSections()[chunkSectionIndex];
+                nearbyChunkSections[2] = chunkPacketInfoAntiXray.getNearbyChunks()[2] == null ? EMPTY_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[2].getSections()[chunkSectionIndex];
+                nearbyChunkSections[3] = chunkPacketInfoAntiXray.getNearbyChunks()[3] == null ? EMPTY_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[3].getSections()[chunkSectionIndex];
 
                 // Obfuscate all layers of the current chunk section except the upper one
                 for (int y = 0; y < 15; y++) {
@@ -505,21 +464,13 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                     next = nextNext;
                     nextNext = temp;
                     random.nextLayer();
-                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, y, bitStorageReader,
-                            bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp,
-                            presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache,
-                            nearbyChunkSections, random, blocks, blockEntities);
+                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, y, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp, presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache, nearbyChunkSections, random, blocks, blockEntities);
                 }
 
                 // Check if the chunk section above doesn't need obfuscation
-                if (chunkSectionIndex == maxChunkSectionIndex
-                        || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex + 1)
-                        || chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex + 1) == null) {
-                    // If so, obfuscate the upper layer of the current chunk section by reading
-                    // blocks of the first layer from the chunk section above if it exists
-                    LevelChunkSection aboveChunkSection = chunkSectionIndex == chunk.getSectionsCount() - 1
-                            ? EMPTY_SECTION
-                            : chunk.getSections()[chunkSectionIndex + 1];
+                if (chunkSectionIndex == maxChunkSectionIndex || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex + 1) || chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex + 1) == null) {
+                    // If so, obfuscate the upper layer of the current chunk section by reading blocks of the first layer from the chunk section above if it exists
+                    LevelChunkSection aboveChunkSection = chunkSectionIndex == chunk.getSectionsCount() - 1 ? EMPTY_SECTION : chunk.getSections()[chunkSectionIndex + 1];
                     boolean aboveChunkSectionEmpty = aboveChunkSection == EMPTY_SECTION;
                     boolean[][] temp = current;
                     current = next;
@@ -538,33 +489,21 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                     bitStorageReader.setBits(0);
                     solid[0] = true;
                     random.nextLayer();
-                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, 15, bitStorageReader,
-                            bitStorageWriter, solid, obfuscateTemp, traceTemp, blockEntityTemp,
-                            presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache,
-                            nearbyChunkSections, random, blocks, blockEntities);
+                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, 15, bitStorageReader, bitStorageWriter, solid, obfuscateTemp, traceTemp, blockEntityTemp, presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache, nearbyChunkSections, random, blocks, blockEntities);
                 } else {
-                    // If not, initialize the reader and other stuff for the chunk section above to
-                    // obfuscate the upper layer of the current chunk section
+                    // If not, initialize the reader and other stuff for the chunk section above to obfuscate the upper layer of the current chunk section
                     bitStorageReader.setBits(chunkPacketInfoAntiXray.getBits(chunkSectionIndex + 1));
                     bitStorageReader.setIndex(chunkPacketInfoAntiXray.getIndex(chunkSectionIndex + 1));
-                    solidTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), solid,
-                            solidGlobal);
-                    obfuscateTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), obfuscate,
-                            obfuscateGlobal);
-                    traceTemp = trace == obfuscate ? obfuscateTemp
-                            : readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), trace,
-                                    traceGlobal);
-                    blockEntityTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1),
-                            blockEntity, blockEntityGlobal);
+                    solidTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), solid, solidGlobal);
+                    obfuscateTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), obfuscate, obfuscateGlobal);
+                    traceTemp = trace == obfuscate ? obfuscateTemp : readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), trace, traceGlobal);
+                    blockEntityTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), blockEntity, blockEntityGlobal);
                     boolean[][] temp = current;
                     current = next;
                     next = nextNext;
                     nextNext = temp;
                     random.nextLayer();
-                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, 15, bitStorageReader,
-                            bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp,
-                            presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache,
-                            nearbyChunkSections, random, blocks, blockEntities);
+                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, 15, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp, presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache, nearbyChunkSections, random, blocks, blockEntities);
                 }
 
                 bitStorageWriter.flush();
@@ -572,14 +511,12 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         }
 
         if (plugin.isRunning()) {
-            plugin.getPacketChunkBlocksCache().put(chunkPacketInfoAntiXray.getChunkPacket(),
-                    new ChunkBlocks(chunkPacketInfoAntiXray.getChunk(), blocks));
+            plugin.getPacketChunkBlocksCache().put(chunkPacketInfoAntiXray.getChunkPacket(), new ChunkBlocks(chunkPacketInfoAntiXray.getChunk(), blocks));
         }
 
         if (!blockEntities.isEmpty()) {
             try {
-                List<?> blockEntitiesData = (List<?>) BLOCK_ENTITIES_DATA_FIELD
-                        .get(chunkPacketInfoAntiXray.getChunkPacket().getChunkData());
+                List<?> blockEntitiesData = (List<?>) BLOCK_ENTITIES_DATA_FIELD.get(chunkPacketInfoAntiXray.getChunkPacket().getChunkData());
                 ChunkPos chunkPos = chunk.getPos();
                 int minX = chunkPos.getMinBlockX();
                 int minZ = chunkPos.getMinBlockZ();
@@ -588,15 +525,12 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                 blockEntitiesData.removeIf(blockEntityData -> {
                     try {
                         int packedXZ = PACKED_X_Z_FIELD.getInt(blockEntityData);
-                        return blockEntities.contains(mutableBlockPos.set(minX + (packedXZ >>> 4),
-                                Y_FIELD.getInt(blockEntityData), minZ + (packedXZ & 15)));
+                        return blockEntities.contains(mutableBlockPos.set(minX + (packedXZ >>> 4), Y_FIELD.getInt(blockEntityData), minZ + (packedXZ & 15)));
                     } catch (IllegalAccessException e) {
                         throw new RuntimeException(e);
                     }
                 });
-                // TODO: Also remove from
-                // chunkPacketInfoAntiXray.getChunkPacket().getExtraPackets(), however, it's
-                // unlikely that it contains anything.
+                // TODO: Also remove from chunkPacketInfoAntiXray.getChunkPacket().getExtraPackets(), however, it's unlikely that it contains anything.
             } catch (IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
@@ -605,12 +539,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         chunkPacketInfoAntiXray.getChunkPacket().setReady(true);
     }
 
-    private void obfuscateLayer(ChunkPos chunkPos, int minSectionY, int chunkSectionIndex, int y,
-            BitStorageReader bitStorageReader, BitStorageWriter bitStorageWriter, boolean[] solid, boolean[] obfuscate,
-            boolean[] trace, boolean[] blockEntity, int[] presetBlockStateBits, boolean[][] current, boolean[][] next,
-            boolean[][] nextNext, boolean[][] traceCache, boolean[][] blockEntityCache,
-            LevelChunkSection[] nearbyChunkSections, IntSupplier random, Map<? super BlockPos, ? super Boolean> blocks,
-            Set<? super BlockPos> blockEntities) {
+    private void obfuscateLayer(ChunkPos chunkPos, int minSectionY, int chunkSectionIndex, int y, BitStorageReader bitStorageReader, BitStorageWriter bitStorageWriter, boolean[] solid, boolean[] obfuscate, boolean[] trace, boolean[] blockEntity, int[] presetBlockStateBits, boolean[][] current, boolean[][] next, boolean[][] nextNext, boolean[][] traceCache, boolean[][] blockEntityCache, LevelChunkSection[] nearbyChunkSections, IntSupplier random, Map<? super BlockPos, ? super Boolean> blocks, Set<? super BlockPos> blockEntities) {
         int minX = chunkPos.getMinBlockX();
         int minZ = chunkPos.getMinBlockZ();
         int realY = (chunkSectionIndex + minSectionY << 4) + y;
@@ -633,8 +562,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             next[0][1] = true;
             next[1][0] = true;
         } else {
-            if (current[0][0] || isTransparent(nearbyChunkSections[2], 0, y, 15)
-                    || isTransparent(nearbyChunkSections[0], 15, y, 0)) {
+            if (current[0][0] || isTransparent(nearbyChunkSections[2], 0, y, 15) || isTransparent(nearbyChunkSections[0], 15, y, 0)) {
                 if (traceCache[0][0] && blocks.size() < maxRayTraceBlockCountPerChunk) {
                     bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]); // Exposed to air
                     BlockPos block = new BlockPos(minX + 0, realY, minZ + 0);
@@ -743,8 +671,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             next[0][14] = true;
             next[1][15] = true;
         } else {
-            if (current[0][15] || isTransparent(nearbyChunkSections[2], 15, y, 15)
-                    || isTransparent(nearbyChunkSections[1], 0, y, 0)) {
+            if (current[0][15] || isTransparent(nearbyChunkSections[2], 15, y, 15) || isTransparent(nearbyChunkSections[1], 0, y, 0)) {
                 if (traceCache[0][15] && blocks.size() < maxRayTraceBlockCountPerChunk) {
                     bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]); // Exposed to air
                     BlockPos block = new BlockPos(minX + 15, realY, minZ + 0);
@@ -965,8 +892,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             next[15][1] = true;
             next[14][0] = true;
         } else {
-            if (current[15][0] || isTransparent(nearbyChunkSections[3], 0, y, 0)
-                    || isTransparent(nearbyChunkSections[0], 15, y, 15)) {
+            if (current[15][0] || isTransparent(nearbyChunkSections[3], 0, y, 0) || isTransparent(nearbyChunkSections[0], 15, y, 15)) {
                 if (traceCache[15][0] && blocks.size() < maxRayTraceBlockCountPerChunk) {
                     bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]); // Exposed to air
                     BlockPos block = new BlockPos(minX + 0, realY, minZ + 15);
@@ -1075,8 +1001,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             next[15][14] = true;
             next[14][15] = true;
         } else {
-            if (current[15][15] || isTransparent(nearbyChunkSections[3], 15, y, 0)
-                    || isTransparent(nearbyChunkSections[1], 0, y, 15)) {
+            if (current[15][15] || isTransparent(nearbyChunkSections[3], 15, y, 0) || isTransparent(nearbyChunkSections[1], 0, y, 15)) {
                 if (traceCache[15][15] && blocks.size() < maxRayTraceBlockCountPerChunk) {
                     bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]); // Exposed to air
                     BlockPos block = new BlockPos(minX + 15, realY, minZ + 15);
@@ -1121,9 +1046,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         } catch (MissingPaletteEntryException e) {
             // Race condition / visibility issue / no happens-before relationship
             // We don't care and treat the block as transparent
-            // Internal implementation details of PalettedContainer, LinearPalette,
-            // HashMapPalette, CrudeIncrementalIntIdentityHashBiMap, ... guarantee us that
-            // no (other) exceptions will occur
+            // Internal implementation details of PalettedContainer, LinearPalette, HashMapPalette, CrudeIncrementalIntIdentityHashBiMap, ... guarantee us that no (other) exceptions will occur
             return true;
         }
     }
@@ -1139,14 +1062,9 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             }
         } catch (MissingPaletteEntryException e) {
             // Race condition / visibility issue / no happens-before relationship
-            // We don't care because we at least see the state as it was when the chunk
-            // packet was created
-            // Internal implementation details of PalettedContainer, LinearPalette,
-            // HashMapPalette, CrudeIncrementalIntIdentityHashBiMap, ... guarantee us that
-            // no (other) exceptions will occur until we have all the data that we need here
-            // Since all palettes have a fixed initial maximum size and there is no internal
-            // restructuring and no values are removed from palettes, we are also guaranteed
-            // to see the data
+            // We don't care because we at least see the state as it was when the chunk packet was created
+            // Internal implementation details of PalettedContainer, LinearPalette, HashMapPalette, CrudeIncrementalIntIdentityHashBiMap, ... guarantee us that no (other) exceptions will occur until we have all the data that we need here
+            // Since all palettes have a fixed initial maximum size and there is no internal restructuring and no values are removed from palettes, we are also guaranteed to see the data
         }
 
         return temp;
@@ -1160,8 +1078,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
     }
 
     @Override
-    public void onPlayerLeftClickBlock(ServerPlayerGameMode serverPlayerGameMode, BlockPos blockPos,
-            ServerboundPlayerActionPacket.Action action, Direction direction, int worldHeight, int sequence) {
+    public void onPlayerLeftClickBlock(ServerPlayerGameMode serverPlayerGameMode, BlockPos blockPos, ServerboundPlayerActionPacket.Action action, Direction direction, int worldHeight, int sequence) {
         if (blockPos.getY() <= maxBlockHeightUpdatePosition) {
             updateNearbyBlocks(serverPlayerGameMode.level, blockPos);
         }

--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/antixray/ChunkPacketBlockControllerAntiXray.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/antixray/ChunkPacketBlockControllerAntiXray.java
@@ -16,7 +16,7 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
-import net.minecraft.resources.Identifier;
+
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -65,13 +65,18 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
     private final int[] presetBlockStateBitsNetherrackGlobal;
     private final int[] presetBlockStateBitsEndStoneGlobal;
     public final boolean[] solidGlobal = new boolean[Block.BLOCK_STATE_REGISTRY.size()];
+    public final Set<Block> bypassRehideBlocks;
     private final boolean[] obfuscateGlobal = new boolean[Block.BLOCK_STATE_REGISTRY.size()];
     private final boolean[] traceGlobal;
     private final boolean[] blockEntityGlobal = new boolean[Block.BLOCK_STATE_REGISTRY.size()];
-    private final LevelChunkSection[] emptyNearbyChunkSections = {EMPTY_SECTION, EMPTY_SECTION, EMPTY_SECTION, EMPTY_SECTION};
+    private final LevelChunkSection[] emptyNearbyChunkSections = { EMPTY_SECTION, EMPTY_SECTION, EMPTY_SECTION,
+            EMPTY_SECTION };
     private final int maxBlockHeightUpdatePosition;
 
-    public ChunkPacketBlockControllerAntiXray(RayTraceAntiXray plugin, ChunkPacketBlockController oldController, boolean rayTraceThirdPerson, double rayTraceDistance, boolean rehideBlocks, double rehideDistance, int maxRayTraceBlockCountPerChunk, Iterable<? extends String> toTrace, Level level, Executor executor) {
+    public ChunkPacketBlockControllerAntiXray(RayTraceAntiXray plugin, ChunkPacketBlockController oldController,
+            boolean rayTraceThirdPerson, double rayTraceDistance, boolean rehideBlocks, double rehideDistance,
+            int maxRayTraceBlockCountPerChunk, Iterable<? extends String> toTrace,
+            Iterable<? extends String> bypassRehideBlocks, Level level, Executor executor) {
         this.plugin = plugin;
         this.oldController = oldController;
         this.executor = executor;
@@ -91,15 +96,19 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             toObfuscate = paperWorldConfig.hiddenBlocks;
             presetBlockStates = null;
             presetBlockStatesFull = null;
-            presetBlockStatesStone = new BlockState[]{Blocks.STONE.defaultBlockState()};
-            presetBlockStatesDeepslate = new BlockState[]{Blocks.DEEPSLATE.defaultBlockState()};
-            presetBlockStatesNetherrack = new BlockState[]{Blocks.NETHERRACK.defaultBlockState()};
-            presetBlockStatesEndStone = new BlockState[]{Blocks.END_STONE.defaultBlockState()};
+            presetBlockStatesStone = new BlockState[] { Blocks.STONE.defaultBlockState() };
+            presetBlockStatesDeepslate = new BlockState[] { Blocks.DEEPSLATE.defaultBlockState() };
+            presetBlockStatesNetherrack = new BlockState[] { Blocks.NETHERRACK.defaultBlockState() };
+            presetBlockStatesEndStone = new BlockState[] { Blocks.END_STONE.defaultBlockState() };
             presetBlockStateBitsGlobal = null;
-            presetBlockStateBitsStoneGlobal = new int[]{GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.STONE.defaultBlockState(), null)};
-            presetBlockStateBitsDeepslateGlobal = new int[]{GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.DEEPSLATE.defaultBlockState(), null)};
-            presetBlockStateBitsNetherrackGlobal = new int[]{GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.NETHERRACK.defaultBlockState(), null)};
-            presetBlockStateBitsEndStoneGlobal = new int[]{GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.END_STONE.defaultBlockState(), null)};
+            presetBlockStateBitsStoneGlobal = new int[] {
+                    GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.STONE.defaultBlockState(), null) };
+            presetBlockStateBitsDeepslateGlobal = new int[] {
+                    GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.DEEPSLATE.defaultBlockState(), null) };
+            presetBlockStateBitsNetherrackGlobal = new int[] {
+                    GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.NETHERRACK.defaultBlockState(), null) };
+            presetBlockStateBitsEndStoneGlobal = new int[] {
+                    GLOBAL_BLOCKSTATE_PALETTE.idFor(Blocks.END_STONE.defaultBlockState(), null) };
         } else {
             toObfuscate = new ArrayList<>(paperWorldConfig.replacementBlocks);
             List<BlockState> presetBlockStateList = new LinkedList<>();
@@ -112,12 +121,19 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                 }
             }
 
-            // The doc of the LinkedHashSet(Collection<? extends E>) constructor doesn't specify that the insertion order is the predictable iteration order of the specified Collection, although it is in the implementation
+            // The doc of the LinkedHashSet(Collection<? extends E>) constructor doesn't
+            // specify that the insertion order is the predictable iteration order of the
+            // specified Collection, although it is in the implementation
             Set<BlockState> presetBlockStateSet = new LinkedHashSet<>();
-            // Therefore addAll(Collection<? extends E>) is used, which guarantees this order in the doc
+            // Therefore addAll(Collection<? extends E>) is used, which guarantees this
+            // order in the doc
             presetBlockStateSet.addAll(presetBlockStateList);
-            presetBlockStates = presetBlockStateSet.isEmpty() ? new BlockState[]{Blocks.DIAMOND_ORE.defaultBlockState()} : presetBlockStateSet.toArray(new BlockState[0]);
-            presetBlockStatesFull = presetBlockStateSet.isEmpty() ? new BlockState[]{Blocks.DIAMOND_ORE.defaultBlockState()} : presetBlockStateList.toArray(new BlockState[0]);
+            presetBlockStates = presetBlockStateSet.isEmpty()
+                    ? new BlockState[] { Blocks.DIAMOND_ORE.defaultBlockState() }
+                    : presetBlockStateSet.toArray(new BlockState[0]);
+            presetBlockStatesFull = presetBlockStateSet.isEmpty()
+                    ? new BlockState[] { Blocks.DIAMOND_ORE.defaultBlockState() }
+                    : presetBlockStateList.toArray(new BlockState[0]);
             presetBlockStatesStone = null;
             presetBlockStatesDeepslate = null;
             presetBlockStatesNetherrack = null;
@@ -136,7 +152,8 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
 
         for (Block block : toObfuscate) {
 
-            // Don't obfuscate air because air causes unnecessary block updates and causes block updates to fail in the void
+            // Don't obfuscate air because air causes unnecessary block updates and causes
+            // block updates to fail in the void
             if (block != null && !block.defaultBlockState().isAir()) {
                 // Replace all block states of a specified block
                 for (BlockState blockState : block.getStateDefinition().getPossibleStates()) {
@@ -151,9 +168,16 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             traceGlobal = new boolean[Block.BLOCK_STATE_REGISTRY.size()];
 
             for (String id : toTrace) {
-                Block block = BuiltInRegistries.BLOCK.getOptional(Identifier.parse(id)).orElse(null);
+                Block block = null;
+                try {
+                    block = getBlock(id);
+                } catch (Exception e) {
+                    plugin.getLogger().warning("Failed to parse ray-trace-block: " + id);
+                    e.printStackTrace();
+                }
 
-                // Don't obfuscate air because air causes unnecessary block updates and causes block updates to fail in the void
+                // Don't obfuscate air because air causes unnecessary block updates and causes
+                // block updates to fail in the void
                 if (block != null && !block.defaultBlockState().isAir()) {
                     // Replace all block states of a specified block
                     for (BlockState blockState : block.getStateDefinition().getPossibleStates()) {
@@ -161,6 +185,24 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                         traceGlobal[blockStateId] = true;
                         obfuscateGlobal[blockStateId] = true;
                     }
+                }
+            }
+        }
+
+        if (bypassRehideBlocks == null) {
+            this.bypassRehideBlocks = null;
+        } else {
+            this.bypassRehideBlocks = new HashSet<>();
+
+            for (String id : bypassRehideBlocks) {
+                try {
+                    Block block = getBlock(id);
+                    if (block != null) {
+                        this.bypassRehideBlocks.add(block);
+                    }
+                } catch (Exception e) {
+                    plugin.getLogger().warning("Failed to parse bypass-rehide-block: " + id);
+                    e.printStackTrace();
                 }
             }
         }
@@ -176,8 +218,13 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             if (blockState != null) {
                 blockEntityGlobal[i] = blockState.hasBlockEntity();
                 solidGlobal[i] = blockState.isRedstoneConductor(emptyChunk, zeroPos)
-                    && blockState.getBlock() != Blocks.SPAWNER && blockState.getBlock() != Blocks.BARRIER && blockState.getBlock() != Blocks.SHULKER_BOX && blockState.getBlock() != Blocks.SLIME_BLOCK && blockState.getBlock() != Blocks.MANGROVE_ROOTS || paperWorldConfig.lavaObscures && blockState == Blocks.LAVA.defaultBlockState();
-                // Comparing blockState == Blocks.LAVA.defaultBlockState() instead of blockState.getBlock() == Blocks.LAVA ensures that only "stationary lava" is used
+                        && blockState.getBlock() != Blocks.SPAWNER && blockState.getBlock() != Blocks.BARRIER
+                        && blockState.getBlock() != Blocks.SHULKER_BOX && blockState.getBlock() != Blocks.SLIME_BLOCK
+                        && blockState.getBlock() != Blocks.MANGROVE_ROOTS
+                        || paperWorldConfig.lavaObscures && blockState == Blocks.LAVA.defaultBlockState();
+                // Comparing blockState == Blocks.LAVA.defaultBlockState() instead of
+                // blockState.getBlock() == Blocks.LAVA ensures that only "stationary lava" is
+                // used
                 // shulker box checks TE.
             }
         }
@@ -195,7 +242,8 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
 
     @Override
     public BlockState[] getPresetBlockStates(Level level, ChunkPos chunkPos, int chunkSectionY) {
-        // Return the block states to be added to the paletted containers so that they can be used for obfuscation
+        // Return the block states to be added to the paletted containers so that they
+        // can be used for obfuscation
         int bottomBlockY = chunkSectionY << 4;
 
         if (bottomBlockY < maxBlockHeight) {
@@ -222,13 +270,16 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
     }
 
     @Override
-    public ChunkPacketInfoAntiXray getChunkPacketInfo(ClientboundLevelChunkWithLightPacket chunkPacket, LevelChunk chunk) {
-        // Return a new instance to collect data and objects in the right state while creating the chunk packet for thread safe access later
+    public ChunkPacketInfoAntiXray getChunkPacketInfo(ClientboundLevelChunkWithLightPacket chunkPacket,
+            LevelChunk chunk) {
+        // Return a new instance to collect data and objects in the right state while
+        // creating the chunk packet for thread safe access later
         return new ChunkPacketInfoAntiXray(chunkPacket, chunk, this);
     }
 
     @Override
-    public void modifyBlocks(ClientboundLevelChunkWithLightPacket chunkPacket, ChunkPacketInfo<BlockState> chunkPacketInfo) {
+    public void modifyBlocks(ClientboundLevelChunkWithLightPacket chunkPacket,
+            ChunkPacketInfo<BlockState> chunkPacketInfo) {
         if (!(chunkPacketInfo instanceof ChunkPacketInfoAntiXray)) {
             chunkPacket.setReady(true);
             return;
@@ -243,29 +294,39 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                     plugin,
                     chunk.getLevel().getWorld(),
                     x, z,
-                    () -> modifyBlocks(chunkPacket, chunkPacketInfo)
-            );
+                    () -> modifyBlocks(chunkPacket, chunkPacketInfo));
             return;
         }
 
         Level level = chunk.getLevel();
-        ((ChunkPacketInfoAntiXray) chunkPacketInfo).setNearbyChunks(level.getChunkIfLoaded(x - 1, z), level.getChunkIfLoaded(x + 1, z), level.getChunkIfLoaded(x, z - 1), level.getChunkIfLoaded(x, z + 1));
+        ((ChunkPacketInfoAntiXray) chunkPacketInfo).setNearbyChunks(level.getChunkIfLoaded(x - 1, z),
+                level.getChunkIfLoaded(x + 1, z), level.getChunkIfLoaded(x, z - 1), level.getChunkIfLoaded(x, z + 1));
         executor.execute((Runnable) chunkPacketInfo);
     }
 
-    // Actually these fields should be variables inside the obfuscate method but in sync mode or with SingleThreadExecutor in async mode it's okay (even without ThreadLocal)
-    // If an ExecutorService with multiple threads is used, ThreadLocal must be used here
-    private final ThreadLocal<int[]> presetBlockStateBits = ThreadLocal.withInitial(() -> new int[getPresetBlockStatesFullLength()]);
-    private static final ThreadLocal<boolean[]> SOLID = ThreadLocal.withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
-    private static final ThreadLocal<boolean[]> OBFUSCATE = ThreadLocal.withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
-    private static final ThreadLocal<boolean[]> TRACE = ThreadLocal.withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
-    private static final ThreadLocal<boolean[]> BLOCK_ENTITY = ThreadLocal.withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
-    // These boolean arrays represent chunk layers, true means don't obfuscate, false means obfuscate
+    // Actually these fields should be variables inside the obfuscate method but in
+    // sync mode or with SingleThreadExecutor in async mode it's okay (even without
+    // ThreadLocal)
+    // If an ExecutorService with multiple threads is used, ThreadLocal must be used
+    // here
+    private final ThreadLocal<int[]> presetBlockStateBits = ThreadLocal
+            .withInitial(() -> new int[getPresetBlockStatesFullLength()]);
+    private static final ThreadLocal<boolean[]> SOLID = ThreadLocal
+            .withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
+    private static final ThreadLocal<boolean[]> OBFUSCATE = ThreadLocal
+            .withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
+    private static final ThreadLocal<boolean[]> TRACE = ThreadLocal
+            .withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
+    private static final ThreadLocal<boolean[]> BLOCK_ENTITY = ThreadLocal
+            .withInitial(() -> new boolean[Block.BLOCK_STATE_REGISTRY.size()]);
+    // These boolean arrays represent chunk layers, true means don't obfuscate,
+    // false means obfuscate
     private static final ThreadLocal<boolean[][]> CURRENT = ThreadLocal.withInitial(() -> new boolean[16][16]);
     private static final ThreadLocal<boolean[][]> NEXT = ThreadLocal.withInitial(() -> new boolean[16][16]);
     private static final ThreadLocal<boolean[][]> NEXT_NEXT = ThreadLocal.withInitial(() -> new boolean[16][16]);
     private static final ThreadLocal<boolean[][]> TRACE_CACHE = ThreadLocal.withInitial(() -> new boolean[16][16]);
-    private static final ThreadLocal<boolean[][]> BLOCK_ENTITY_CACHE = ThreadLocal.withInitial(() -> new boolean[16][16]);
+    private static final ThreadLocal<boolean[][]> BLOCK_ENTITY_CACHE = ThreadLocal
+            .withInitial(() -> new boolean[16][16]);
     private static final Field BLOCK_ENTITIES_DATA_FIELD;
     private static final Field PACKED_X_Z_FIELD;
     private static final Field Y_FIELD;
@@ -274,7 +335,8 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         try {
             BLOCK_ENTITIES_DATA_FIELD = ClientboundLevelChunkPacketData.class.getDeclaredField("blockEntitiesData");
             BLOCK_ENTITIES_DATA_FIELD.setAccessible(true);
-            Class<?> blockEntityInfoClass = Class.forName("net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData$BlockEntityInfo");
+            Class<?> blockEntityInfoClass = Class
+                    .forName("net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData$BlockEntityInfo");
             PACKED_X_Z_FIELD = blockEntityInfoClass.getDeclaredField("packedXZ");
             PACKED_X_Z_FIELD.setAccessible(true);
             Y_FIELD = blockEntityInfoClass.getDeclaredField("y");
@@ -295,13 +357,15 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         boolean[][] nextNext = NEXT_NEXT.get();
         boolean[][] traceCache = TRACE_CACHE.get();
         boolean[][] blockEntityCache = BLOCK_ENTITY_CACHE.get();
-        // bitStorageReader, bitStorageWriter and nearbyChunkSections could also be reused (with ThreadLocal if necessary) but it's not worth it
+        // bitStorageReader, bitStorageWriter and nearbyChunkSections could also be
+        // reused (with ThreadLocal if necessary) but it's not worth it
         BitStorageReader bitStorageReader = new BitStorageReader();
         BitStorageWriter bitStorageWriter = new BitStorageWriter();
         LevelChunkSection[] nearbyChunkSections = new LevelChunkSection[4];
         LevelChunk chunk = chunkPacketInfoAntiXray.getChunk();
         Level level = chunk.getLevel();
-        int maxChunkSectionIndex = Math.min((maxBlockHeight >> 4) - chunk.getMinSectionY(), chunk.getSectionsCount()) - 1;
+        int maxChunkSectionIndex = Math.min((maxBlockHeight >> 4) - chunk.getMinSectionY(), chunk.getSectionsCount())
+                - 1;
         boolean[] solidTemp = null;
         boolean[] obfuscateTemp = null;
         boolean[] traceTemp = null;
@@ -309,53 +373,58 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         bitStorageReader.setBuffer(chunkPacketInfoAntiXray.getBuffer());
         bitStorageWriter.setBuffer(chunkPacketInfoAntiXray.getBuffer());
         int numberOfBlocks = presetBlockStateBits.length;
-        // Keep the lambda expressions as simple as possible. They are used very frequently.
-        LayeredIntSupplier random = numberOfBlocks == 1 ? (() -> 0) : engineMode == EngineMode.OBFUSCATE_LAYER ? new LayeredIntSupplier() {
-            // engine-mode: 3
-            private int state;
-            private int next;
+        // Keep the lambda expressions as simple as possible. They are used very
+        // frequently.
+        LayeredIntSupplier random = numberOfBlocks == 1 ? (() -> 0)
+                : engineMode == EngineMode.OBFUSCATE_LAYER ? new LayeredIntSupplier() {
+                    // engine-mode: 3
+                    private int state;
+                    private int next;
 
-            {
-                while ((state = ThreadLocalRandom.current().nextInt()) == 0) ;
-            }
+                    {
+                        while ((state = ThreadLocalRandom.current().nextInt()) == 0)
+                            ;
+                    }
 
-            @Override
-            public void nextLayer() {
-                // https://en.wikipedia.org/wiki/Xorshift
-                state ^= state << 13;
-                state ^= state >>> 17;
-                state ^= state << 5;
-                // https://www.pcg-random.org/posts/bounded-rands.html
-                next = (int) ((Integer.toUnsignedLong(state) * numberOfBlocks) >>> 32);
-            }
+                    @Override
+                    public void nextLayer() {
+                        // https://en.wikipedia.org/wiki/Xorshift
+                        state ^= state << 13;
+                        state ^= state >>> 17;
+                        state ^= state << 5;
+                        // https://www.pcg-random.org/posts/bounded-rands.html
+                        next = (int) ((Integer.toUnsignedLong(state) * numberOfBlocks) >>> 32);
+                    }
 
-            @Override
-            public int getAsInt() {
-                return next;
-            }
-        } : new LayeredIntSupplier() {
-            // engine-mode: 2
-            private int state;
+                    @Override
+                    public int getAsInt() {
+                        return next;
+                    }
+                } : new LayeredIntSupplier() {
+                    // engine-mode: 2
+                    private int state;
 
-            {
-                while ((state = ThreadLocalRandom.current().nextInt()) == 0) ;
-            }
+                    {
+                        while ((state = ThreadLocalRandom.current().nextInt()) == 0)
+                            ;
+                    }
 
-            @Override
-            public int getAsInt() {
-                // https://en.wikipedia.org/wiki/Xorshift
-                state ^= state << 13;
-                state ^= state >>> 17;
-                state ^= state << 5;
-                // https://www.pcg-random.org/posts/bounded-rands.html
-                return (int) ((Integer.toUnsignedLong(state) * numberOfBlocks) >>> 32);
-            }
-        };
+                    @Override
+                    public int getAsInt() {
+                        // https://en.wikipedia.org/wiki/Xorshift
+                        state ^= state << 13;
+                        state ^= state >>> 17;
+                        state ^= state << 5;
+                        // https://www.pcg-random.org/posts/bounded-rands.html
+                        return (int) ((Integer.toUnsignedLong(state) * numberOfBlocks) >>> 32);
+                    }
+                };
         HashMap<BlockPos, Boolean> blocks = new HashMap<>();
         HashSet<BlockPos> blockEntities = new HashSet<>();
 
         for (int chunkSectionIndex = 0; chunkSectionIndex <= maxChunkSectionIndex; chunkSectionIndex++) {
-            if (chunkPacketInfoAntiXray.isWritten(chunkSectionIndex) && chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex) != null) {
+            if (chunkPacketInfoAntiXray.isWritten(chunkSectionIndex)
+                    && chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex) != null) {
                 int[] presetBlockStateBitsTemp;
 
                 if (chunkPacketInfoAntiXray.getPalette(chunkSectionIndex) instanceof GlobalPalette) {
@@ -368,37 +437,48 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                                 presetBlockStateBitsTemp = presetBlockStateBitsEndStoneGlobal;
                                 break;
                             default:
-                                presetBlockStateBitsTemp = chunkSectionIndex + chunk.getMinSectionY() < 0 ? presetBlockStateBitsDeepslateGlobal : presetBlockStateBitsStoneGlobal;
+                                presetBlockStateBitsTemp = chunkSectionIndex + chunk.getMinSectionY() < 0
+                                        ? presetBlockStateBitsDeepslateGlobal
+                                        : presetBlockStateBitsStoneGlobal;
                         }
                     } else {
                         presetBlockStateBitsTemp = presetBlockStateBitsGlobal;
                     }
                 } else {
                     // If it's presetBlockStates, use this.presetBlockStatesFull instead
-                    BlockState[] presetBlockStatesFull = chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex) == presetBlockStates ? this.presetBlockStatesFull : chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex);
+                    BlockState[] presetBlockStatesFull = chunkPacketInfoAntiXray
+                            .getPresetValues(chunkSectionIndex) == presetBlockStates ? this.presetBlockStatesFull
+                                    : chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex);
                     presetBlockStateBitsTemp = presetBlockStateBits;
 
                     for (int i = 0; i < presetBlockStateBitsTemp.length; i++) {
-                        // This is thread safe because we only request IDs that are guaranteed to be in the palette and are visible
+                        // This is thread safe because we only request IDs that are guaranteed to be in
+                        // the palette and are visible
                         // For more details see the comments in the readPalette method
-                        presetBlockStateBitsTemp[i] = chunkPacketInfoAntiXray.getPalette(chunkSectionIndex).idFor(presetBlockStatesFull[i], null);
+                        presetBlockStateBitsTemp[i] = chunkPacketInfoAntiXray.getPalette(chunkSectionIndex)
+                                .idFor(presetBlockStatesFull[i], null);
                     }
                 }
 
                 bitStorageWriter.setIndex(chunkPacketInfoAntiXray.getIndex(chunkSectionIndex));
 
                 // Check if the chunk section below was not obfuscated
-                if (chunkSectionIndex == 0 || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex - 1) || chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex - 1) == null) {
+                if (chunkSectionIndex == 0 || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex - 1)
+                        || chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex - 1) == null) {
                     // If so, initialize some stuff
                     bitStorageReader.setBits(chunkPacketInfoAntiXray.getBits(chunkSectionIndex));
                     bitStorageReader.setIndex(chunkPacketInfoAntiXray.getIndex(chunkSectionIndex));
                     solidTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), solid, solidGlobal);
-                    obfuscateTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), obfuscate, obfuscateGlobal);
-                    traceTemp = trace == obfuscate ? obfuscateTemp : readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), trace, traceGlobal);
-                    blockEntityTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), blockEntity, blockEntityGlobal);
+                    obfuscateTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), obfuscate,
+                            obfuscateGlobal);
+                    traceTemp = trace == obfuscate ? obfuscateTemp
+                            : readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), trace, traceGlobal);
+                    blockEntityTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex), blockEntity,
+                            blockEntityGlobal);
                     // Read the blocks of the upper layer of the chunk section below if it exists
                     LevelChunkSection belowChunkSection = null;
-                    boolean skipFirstLayer = chunkSectionIndex == 0 || (belowChunkSection = chunk.getSections()[chunkSectionIndex - 1]) == EMPTY_SECTION;
+                    boolean skipFirstLayer = chunkSectionIndex == 0
+                            || (belowChunkSection = chunk.getSections()[chunkSectionIndex - 1]) == EMPTY_SECTION;
 
                     for (int z = 0; z < 16; z++) {
                         for (int x = 0; x < 16; x++) {
@@ -408,16 +488,24 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                         }
                     }
 
-                    // Abuse the obfuscateLayer method to read the blocks of the first layer of the current chunk section
+                    // Abuse the obfuscateLayer method to read the blocks of the first layer of the
+                    // current chunk section
                     bitStorageWriter.setBits(0);
-                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, -1, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp, presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache, emptyNearbyChunkSections, random, blocks, blockEntities);
+                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, -1, bitStorageReader,
+                            bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp,
+                            presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache,
+                            emptyNearbyChunkSections, random, blocks, blockEntities);
                 }
 
                 bitStorageWriter.setBits(chunkPacketInfoAntiXray.getBits(chunkSectionIndex));
-                nearbyChunkSections[0] = chunkPacketInfoAntiXray.getNearbyChunks()[0] == null ? EMPTY_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[0].getSections()[chunkSectionIndex];
-                nearbyChunkSections[1] = chunkPacketInfoAntiXray.getNearbyChunks()[1] == null ? EMPTY_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[1].getSections()[chunkSectionIndex];
-                nearbyChunkSections[2] = chunkPacketInfoAntiXray.getNearbyChunks()[2] == null ? EMPTY_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[2].getSections()[chunkSectionIndex];
-                nearbyChunkSections[3] = chunkPacketInfoAntiXray.getNearbyChunks()[3] == null ? EMPTY_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[3].getSections()[chunkSectionIndex];
+                nearbyChunkSections[0] = chunkPacketInfoAntiXray.getNearbyChunks()[0] == null ? EMPTY_SECTION
+                        : chunkPacketInfoAntiXray.getNearbyChunks()[0].getSections()[chunkSectionIndex];
+                nearbyChunkSections[1] = chunkPacketInfoAntiXray.getNearbyChunks()[1] == null ? EMPTY_SECTION
+                        : chunkPacketInfoAntiXray.getNearbyChunks()[1].getSections()[chunkSectionIndex];
+                nearbyChunkSections[2] = chunkPacketInfoAntiXray.getNearbyChunks()[2] == null ? EMPTY_SECTION
+                        : chunkPacketInfoAntiXray.getNearbyChunks()[2].getSections()[chunkSectionIndex];
+                nearbyChunkSections[3] = chunkPacketInfoAntiXray.getNearbyChunks()[3] == null ? EMPTY_SECTION
+                        : chunkPacketInfoAntiXray.getNearbyChunks()[3].getSections()[chunkSectionIndex];
 
                 // Obfuscate all layers of the current chunk section except the upper one
                 for (int y = 0; y < 15; y++) {
@@ -426,13 +514,21 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                     next = nextNext;
                     nextNext = temp;
                     random.nextLayer();
-                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, y, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp, presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache, nearbyChunkSections, random, blocks, blockEntities);
+                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, y, bitStorageReader,
+                            bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp,
+                            presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache,
+                            nearbyChunkSections, random, blocks, blockEntities);
                 }
 
                 // Check if the chunk section above doesn't need obfuscation
-                if (chunkSectionIndex == maxChunkSectionIndex || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex + 1) || chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex + 1) == null) {
-                    // If so, obfuscate the upper layer of the current chunk section by reading blocks of the first layer from the chunk section above if it exists
-                    LevelChunkSection aboveChunkSection = chunkSectionIndex == chunk.getSectionsCount() - 1 ? EMPTY_SECTION : chunk.getSections()[chunkSectionIndex + 1];
+                if (chunkSectionIndex == maxChunkSectionIndex
+                        || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex + 1)
+                        || chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex + 1) == null) {
+                    // If so, obfuscate the upper layer of the current chunk section by reading
+                    // blocks of the first layer from the chunk section above if it exists
+                    LevelChunkSection aboveChunkSection = chunkSectionIndex == chunk.getSectionsCount() - 1
+                            ? EMPTY_SECTION
+                            : chunk.getSections()[chunkSectionIndex + 1];
                     boolean aboveChunkSectionEmpty = aboveChunkSection == EMPTY_SECTION;
                     boolean[][] temp = current;
                     current = next;
@@ -451,21 +547,33 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                     bitStorageReader.setBits(0);
                     solid[0] = true;
                     random.nextLayer();
-                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, 15, bitStorageReader, bitStorageWriter, solid, obfuscateTemp, traceTemp, blockEntityTemp, presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache, nearbyChunkSections, random, blocks, blockEntities);
+                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, 15, bitStorageReader,
+                            bitStorageWriter, solid, obfuscateTemp, traceTemp, blockEntityTemp,
+                            presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache,
+                            nearbyChunkSections, random, blocks, blockEntities);
                 } else {
-                    // If not, initialize the reader and other stuff for the chunk section above to obfuscate the upper layer of the current chunk section
+                    // If not, initialize the reader and other stuff for the chunk section above to
+                    // obfuscate the upper layer of the current chunk section
                     bitStorageReader.setBits(chunkPacketInfoAntiXray.getBits(chunkSectionIndex + 1));
                     bitStorageReader.setIndex(chunkPacketInfoAntiXray.getIndex(chunkSectionIndex + 1));
-                    solidTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), solid, solidGlobal);
-                    obfuscateTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), obfuscate, obfuscateGlobal);
-                    traceTemp = trace == obfuscate ? obfuscateTemp : readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), trace, traceGlobal);
-                    blockEntityTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), blockEntity, blockEntityGlobal);
+                    solidTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), solid,
+                            solidGlobal);
+                    obfuscateTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), obfuscate,
+                            obfuscateGlobal);
+                    traceTemp = trace == obfuscate ? obfuscateTemp
+                            : readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1), trace,
+                                    traceGlobal);
+                    blockEntityTemp = readPalette(chunkPacketInfoAntiXray.getPalette(chunkSectionIndex + 1),
+                            blockEntity, blockEntityGlobal);
                     boolean[][] temp = current;
                     current = next;
                     next = nextNext;
                     nextNext = temp;
                     random.nextLayer();
-                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, 15, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp, presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache, nearbyChunkSections, random, blocks, blockEntities);
+                    obfuscateLayer(chunk.getPos(), chunk.getMinSectionY(), chunkSectionIndex, 15, bitStorageReader,
+                            bitStorageWriter, solidTemp, obfuscateTemp, traceTemp, blockEntityTemp,
+                            presetBlockStateBitsTemp, current, next, nextNext, traceCache, blockEntityCache,
+                            nearbyChunkSections, random, blocks, blockEntities);
                 }
 
                 bitStorageWriter.flush();
@@ -473,12 +581,14 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         }
 
         if (plugin.isRunning()) {
-            plugin.getPacketChunkBlocksCache().put(chunkPacketInfoAntiXray.getChunkPacket(), new ChunkBlocks(chunkPacketInfoAntiXray.getChunk(), blocks));
+            plugin.getPacketChunkBlocksCache().put(chunkPacketInfoAntiXray.getChunkPacket(),
+                    new ChunkBlocks(chunkPacketInfoAntiXray.getChunk(), blocks));
         }
 
         if (!blockEntities.isEmpty()) {
             try {
-                List<?> blockEntitiesData = (List<?>) BLOCK_ENTITIES_DATA_FIELD.get(chunkPacketInfoAntiXray.getChunkPacket().getChunkData());
+                List<?> blockEntitiesData = (List<?>) BLOCK_ENTITIES_DATA_FIELD
+                        .get(chunkPacketInfoAntiXray.getChunkPacket().getChunkData());
                 ChunkPos chunkPos = chunk.getPos();
                 int minX = chunkPos.getMinBlockX();
                 int minZ = chunkPos.getMinBlockZ();
@@ -487,12 +597,15 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
                 blockEntitiesData.removeIf(blockEntityData -> {
                     try {
                         int packedXZ = PACKED_X_Z_FIELD.getInt(blockEntityData);
-                        return blockEntities.contains(mutableBlockPos.set(minX + (packedXZ >>> 4), Y_FIELD.getInt(blockEntityData), minZ + (packedXZ & 15)));
+                        return blockEntities.contains(mutableBlockPos.set(minX + (packedXZ >>> 4),
+                                Y_FIELD.getInt(blockEntityData), minZ + (packedXZ & 15)));
                     } catch (IllegalAccessException e) {
                         throw new RuntimeException(e);
                     }
                 });
-                // TODO: Also remove from chunkPacketInfoAntiXray.getChunkPacket().getExtraPackets(), however, it's unlikely that it contains anything.
+                // TODO: Also remove from
+                // chunkPacketInfoAntiXray.getChunkPacket().getExtraPackets(), however, it's
+                // unlikely that it contains anything.
             } catch (IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
@@ -501,7 +614,12 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         chunkPacketInfoAntiXray.getChunkPacket().setReady(true);
     }
 
-    private void obfuscateLayer(ChunkPos chunkPos, int minSectionY, int chunkSectionIndex, int y, BitStorageReader bitStorageReader, BitStorageWriter bitStorageWriter, boolean[] solid, boolean[] obfuscate, boolean[] trace, boolean[] blockEntity, int[] presetBlockStateBits, boolean[][] current, boolean[][] next, boolean[][] nextNext, boolean[][] traceCache, boolean[][] blockEntityCache, LevelChunkSection[] nearbyChunkSections, IntSupplier random, Map<? super BlockPos, ? super Boolean> blocks, Set<? super BlockPos> blockEntities) {
+    private void obfuscateLayer(ChunkPos chunkPos, int minSectionY, int chunkSectionIndex, int y,
+            BitStorageReader bitStorageReader, BitStorageWriter bitStorageWriter, boolean[] solid, boolean[] obfuscate,
+            boolean[] trace, boolean[] blockEntity, int[] presetBlockStateBits, boolean[][] current, boolean[][] next,
+            boolean[][] nextNext, boolean[][] traceCache, boolean[][] blockEntityCache,
+            LevelChunkSection[] nearbyChunkSections, IntSupplier random, Map<? super BlockPos, ? super Boolean> blocks,
+            Set<? super BlockPos> blockEntities) {
         int minX = chunkPos.getMinBlockX();
         int minZ = chunkPos.getMinBlockZ();
         int realY = (chunkSectionIndex + minSectionY << 4) + y;
@@ -524,7 +642,8 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             next[0][1] = true;
             next[1][0] = true;
         } else {
-            if (current[0][0] || isTransparent(nearbyChunkSections[2], 0, y, 15) || isTransparent(nearbyChunkSections[0], 15, y, 0)) {
+            if (current[0][0] || isTransparent(nearbyChunkSections[2], 0, y, 15)
+                    || isTransparent(nearbyChunkSections[0], 15, y, 0)) {
                 if (traceCache[0][0] && blocks.size() < maxRayTraceBlockCountPerChunk) {
                     bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]); // Exposed to air
                     BlockPos block = new BlockPos(minX + 0, realY, minZ + 0);
@@ -633,7 +752,8 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             next[0][14] = true;
             next[1][15] = true;
         } else {
-            if (current[0][15] || isTransparent(nearbyChunkSections[2], 15, y, 15) || isTransparent(nearbyChunkSections[1], 0, y, 0)) {
+            if (current[0][15] || isTransparent(nearbyChunkSections[2], 15, y, 15)
+                    || isTransparent(nearbyChunkSections[1], 0, y, 0)) {
                 if (traceCache[0][15] && blocks.size() < maxRayTraceBlockCountPerChunk) {
                     bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]); // Exposed to air
                     BlockPos block = new BlockPos(minX + 15, realY, minZ + 0);
@@ -854,7 +974,8 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             next[15][1] = true;
             next[14][0] = true;
         } else {
-            if (current[15][0] || isTransparent(nearbyChunkSections[3], 0, y, 0) || isTransparent(nearbyChunkSections[0], 15, y, 15)) {
+            if (current[15][0] || isTransparent(nearbyChunkSections[3], 0, y, 0)
+                    || isTransparent(nearbyChunkSections[0], 15, y, 15)) {
                 if (traceCache[15][0] && blocks.size() < maxRayTraceBlockCountPerChunk) {
                     bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]); // Exposed to air
                     BlockPos block = new BlockPos(minX + 0, realY, minZ + 15);
@@ -963,7 +1084,8 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             next[15][14] = true;
             next[14][15] = true;
         } else {
-            if (current[15][15] || isTransparent(nearbyChunkSections[3], 15, y, 0) || isTransparent(nearbyChunkSections[1], 0, y, 15)) {
+            if (current[15][15] || isTransparent(nearbyChunkSections[3], 15, y, 0)
+                    || isTransparent(nearbyChunkSections[1], 0, y, 15)) {
                 if (traceCache[15][15] && blocks.size() < maxRayTraceBlockCountPerChunk) {
                     bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]); // Exposed to air
                     BlockPos block = new BlockPos(minX + 15, realY, minZ + 15);
@@ -1008,7 +1130,9 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         } catch (MissingPaletteEntryException e) {
             // Race condition / visibility issue / no happens-before relationship
             // We don't care and treat the block as transparent
-            // Internal implementation details of PalettedContainer, LinearPalette, HashMapPalette, CrudeIncrementalIntIdentityHashBiMap, ... guarantee us that no (other) exceptions will occur
+            // Internal implementation details of PalettedContainer, LinearPalette,
+            // HashMapPalette, CrudeIncrementalIntIdentityHashBiMap, ... guarantee us that
+            // no (other) exceptions will occur
             return true;
         }
     }
@@ -1024,23 +1148,32 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
             }
         } catch (MissingPaletteEntryException e) {
             // Race condition / visibility issue / no happens-before relationship
-            // We don't care because we at least see the state as it was when the chunk packet was created
-            // Internal implementation details of PalettedContainer, LinearPalette, HashMapPalette, CrudeIncrementalIntIdentityHashBiMap, ... guarantee us that no (other) exceptions will occur until we have all the data that we need here
-            // Since all palettes have a fixed initial maximum size and there is no internal restructuring and no values are removed from palettes, we are also guaranteed to see the data
+            // We don't care because we at least see the state as it was when the chunk
+            // packet was created
+            // Internal implementation details of PalettedContainer, LinearPalette,
+            // HashMapPalette, CrudeIncrementalIntIdentityHashBiMap, ... guarantee us that
+            // no (other) exceptions will occur until we have all the data that we need here
+            // Since all palettes have a fixed initial maximum size and there is no internal
+            // restructuring and no values are removed from palettes, we are also guaranteed
+            // to see the data
         }
 
         return temp;
     }
 
     @Override
-    public void onBlockChange(Level level, BlockPos blockPos, BlockState newBlockState, BlockState oldBlockState, int flags, int maxUpdateDepth) {
-        if (oldBlockState != null && solidGlobal[GLOBAL_BLOCKSTATE_PALETTE.idFor(oldBlockState, null)] && !solidGlobal[GLOBAL_BLOCKSTATE_PALETTE.idFor(newBlockState, null)] && blockPos.getY() <= maxBlockHeightUpdatePosition) {
+    public void onBlockChange(Level level, BlockPos blockPos, BlockState newBlockState, BlockState oldBlockState,
+            int flags, int maxUpdateDepth) {
+        if (oldBlockState != null && solidGlobal[GLOBAL_BLOCKSTATE_PALETTE.idFor(oldBlockState, null)]
+                && !solidGlobal[GLOBAL_BLOCKSTATE_PALETTE.idFor(newBlockState, null)]
+                && blockPos.getY() <= maxBlockHeightUpdatePosition) {
             updateNearbyBlocks(level, blockPos);
         }
     }
 
     @Override
-    public void onPlayerLeftClickBlock(ServerPlayerGameMode serverPlayerGameMode, BlockPos blockPos, ServerboundPlayerActionPacket.Action action, Direction direction, int worldHeight, int sequence) {
+    public void onPlayerLeftClickBlock(ServerPlayerGameMode serverPlayerGameMode, BlockPos blockPos,
+            ServerboundPlayerActionPacket.Action action, Direction direction, int worldHeight, int sequence) {
         if (blockPos.getY() <= maxBlockHeightUpdatePosition) {
             updateNearbyBlocks(serverPlayerGameMode.level, blockPos);
         }
@@ -1098,5 +1231,29 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         default void nextLayer() {
 
         }
+    }
+
+    private static Block getBlock(String id) throws Exception {
+        Class<?> keyClass;
+        try {
+            keyClass = Class.forName("net.minecraft.resources.ResourceLocation");
+        } catch (ClassNotFoundException e) {
+            keyClass = Class.forName("net.minecraft.resources.Identifier");
+        }
+
+        Object key;
+        try {
+            java.lang.reflect.Method parseMethod = keyClass.getMethod("parse", String.class);
+            key = parseMethod.invoke(null, id);
+        } catch (NoSuchMethodException e) {
+            java.lang.reflect.Constructor<?> ctor = keyClass.getConstructor(String.class);
+            key = ctor.newInstance(id);
+        }
+
+        java.lang.reflect.Method getOptionalMethod = BuiltInRegistries.BLOCK.getClass().getMethod("getOptional",
+                keyClass);
+        java.util.Optional<?> optional = (java.util.Optional<?>) getOptionalMethod.invoke(BuiltInRegistries.BLOCK, key);
+
+        return (Block) optional.orElse(null);
     }
 }

--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/listeners/WorldListener.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/listeners/WorldListener.java
@@ -40,35 +40,30 @@ public final class WorldListener implements Listener {
         if (plugin.isEnabled(world)) {
             FileConfiguration config = plugin.getConfig();
             String worldName = world.getName();
-            boolean rayTraceThirdPerson = config.getBoolean(
-                    "world-settings." + worldName + ".anti-xray.ray-trace-third-person",
-                    config.getBoolean("world-settings.default.anti-xray.ray-trace-third-person"));
-            double rayTraceDistance = Math
-                    .max(config.getDouble("world-settings." + worldName + ".anti-xray.ray-trace-distance",
-                            config.getDouble("world-settings.default.anti-xray.ray-trace-distance")), 0.);
-            boolean rehideBlocks = config.getBoolean("world-settings." + worldName + ".anti-xray.rehide-blocks",
-                    config.getBoolean("world-settings.default.anti-xray.rehide-blocks"));
-            double rehideDistance = Math
-                    .max(config.getDouble("world-settings." + worldName + ".anti-xray.rehide-distance",
-                            config.getDouble("world-settings.default.anti-xray.rehide-distance")), 0.);
-            int maxRayTraceBlockCountPerChunk = Math
-                    .max(config.getInt("world-settings." + worldName + ".anti-xray.max-ray-trace-block-count-per-chunk",
-                            config.getInt("world-settings.default.anti-xray.max-ray-trace-block-count-per-chunk")), 0);
-            List<String> rayTraceBlocks = config
-                    .getList("world-settings." + worldName + ".anti-xray.ray-trace-blocks",
-                            config.getList("world-settings.default.anti-xray.ray-trace-blocks"))
-                    .stream().filter(Objects::nonNull).map(String::valueOf).collect(Collectors.toList());
+            boolean rayTraceThirdPerson = config.getBoolean("world-settings." + worldName + ".anti-xray.ray-trace-third-person", config.getBoolean("world-settings.default.anti-xray.ray-trace-third-person"));
+            double rayTraceDistance = Math.max(config.getDouble("world-settings." + worldName + ".anti-xray.ray-trace-distance", config.getDouble("world-settings.default.anti-xray.ray-trace-distance")), 0.);
+            boolean rehideBlocks = config.getBoolean("world-settings." + worldName + ".anti-xray.rehide-blocks", config.getBoolean("world-settings.default.anti-xray.rehide-blocks"));
+            double rehideDistance = Math.max(config.getDouble("world-settings." + worldName + ".anti-xray.rehide-distance", config.getDouble("world-settings.default.anti-xray.rehide-distance")), 0.);
+            int maxRayTraceBlockCountPerChunk = Math.max(config.getInt("world-settings." + worldName + ".anti-xray.max-ray-trace-block-count-per-chunk", config.getInt("world-settings.default.anti-xray.max-ray-trace-block-count-per-chunk")), 0);
+            List<String> rayTraceBlocks = config.getList("world-settings." + worldName + ".anti-xray.ray-trace-blocks", config.getList("world-settings.default.anti-xray.ray-trace-blocks")).stream().filter(Objects::nonNull).map(String::valueOf).collect(Collectors.toList());
             List<String> bypassRehideBlocks = config
                     .getList("world-settings." + worldName + ".anti-xray.bypass-rehide-blocks",
                             config.getList("world-settings.default.anti-xray.bypass-rehide-blocks"))
                     .stream().filter(Objects::nonNull).map(String::valueOf).collect(Collectors.toList());
             ServerLevel serverLevel = ((CraftWorld) world).getHandle();
-            ChunkPacketBlockControllerAntiXray controller = new ChunkPacketBlockControllerAntiXray(plugin,
-                    ((CraftWorld) world).getHandle().chunkPacketBlockController, rayTraceThirdPerson, rayTraceDistance,
-                    rehideBlocks, rehideDistance, maxRayTraceBlockCountPerChunk,
+            ChunkPacketBlockControllerAntiXray controller = new ChunkPacketBlockControllerAntiXray(
+                    plugin,
+                    ((CraftWorld) world).getHandle().chunkPacketBlockController,
+                    rayTraceThirdPerson,
+                    rayTraceDistance,
+                    rehideBlocks,
+                    rehideDistance,
+                    maxRayTraceBlockCountPerChunk,
                     rayTraceBlocks.isEmpty() ? null : rayTraceBlocks,
-                    bypassRehideBlocks.isEmpty() ? null : bypassRehideBlocks, serverLevel,
-                    MinecraftServer.getServer().executor);
+                    bypassRehideBlocks.isEmpty() ? null : bypassRehideBlocks,
+                    serverLevel,
+                    MinecraftServer.getServer().executor
+            );
 
             try {
                 Field field = Level.class.getDeclaredField("chunkPacketBlockController");
@@ -82,8 +77,7 @@ public final class WorldListener implements Listener {
 
     public static void handleUnload(RayTraceAntiXray plugin, World w) {
         if (((CraftWorld) w).getHandle().chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray) {
-            ChunkPacketBlockController oldController = ((ChunkPacketBlockControllerAntiXray) ((CraftWorld) w)
-                    .getHandle().chunkPacketBlockController).getOldController();
+            ChunkPacketBlockController oldController = ((ChunkPacketBlockControllerAntiXray) ((CraftWorld) w).getHandle().chunkPacketBlockController).getOldController();
 
             try {
                 Field field = Level.class.getDeclaredField("chunkPacketBlockController");

--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/listeners/WorldListener.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/listeners/WorldListener.java
@@ -40,14 +40,35 @@ public final class WorldListener implements Listener {
         if (plugin.isEnabled(world)) {
             FileConfiguration config = plugin.getConfig();
             String worldName = world.getName();
-            boolean rayTraceThirdPerson = config.getBoolean("world-settings." + worldName + ".anti-xray.ray-trace-third-person", config.getBoolean("world-settings.default.anti-xray.ray-trace-third-person"));
-            double rayTraceDistance = Math.max(config.getDouble("world-settings." + worldName + ".anti-xray.ray-trace-distance", config.getDouble("world-settings.default.anti-xray.ray-trace-distance")), 0.);
-            boolean rehideBlocks = config.getBoolean("world-settings." + worldName + ".anti-xray.rehide-blocks", config.getBoolean("world-settings.default.anti-xray.rehide-blocks"));
-            double rehideDistance = Math.max(config.getDouble("world-settings." + worldName + ".anti-xray.rehide-distance", config.getDouble("world-settings.default.anti-xray.rehide-distance")), 0.);
-            int maxRayTraceBlockCountPerChunk = Math.max(config.getInt("world-settings." + worldName + ".anti-xray.max-ray-trace-block-count-per-chunk", config.getInt("world-settings.default.anti-xray.max-ray-trace-block-count-per-chunk")), 0);
-            List<String> rayTraceBlocks = config.getList("world-settings." + worldName + ".anti-xray.ray-trace-blocks", config.getList("world-settings.default.anti-xray.ray-trace-blocks")).stream().filter(Objects::nonNull).map(String::valueOf).collect(Collectors.toList());
+            boolean rayTraceThirdPerson = config.getBoolean(
+                    "world-settings." + worldName + ".anti-xray.ray-trace-third-person",
+                    config.getBoolean("world-settings.default.anti-xray.ray-trace-third-person"));
+            double rayTraceDistance = Math
+                    .max(config.getDouble("world-settings." + worldName + ".anti-xray.ray-trace-distance",
+                            config.getDouble("world-settings.default.anti-xray.ray-trace-distance")), 0.);
+            boolean rehideBlocks = config.getBoolean("world-settings." + worldName + ".anti-xray.rehide-blocks",
+                    config.getBoolean("world-settings.default.anti-xray.rehide-blocks"));
+            double rehideDistance = Math
+                    .max(config.getDouble("world-settings." + worldName + ".anti-xray.rehide-distance",
+                            config.getDouble("world-settings.default.anti-xray.rehide-distance")), 0.);
+            int maxRayTraceBlockCountPerChunk = Math
+                    .max(config.getInt("world-settings." + worldName + ".anti-xray.max-ray-trace-block-count-per-chunk",
+                            config.getInt("world-settings.default.anti-xray.max-ray-trace-block-count-per-chunk")), 0);
+            List<String> rayTraceBlocks = config
+                    .getList("world-settings." + worldName + ".anti-xray.ray-trace-blocks",
+                            config.getList("world-settings.default.anti-xray.ray-trace-blocks"))
+                    .stream().filter(Objects::nonNull).map(String::valueOf).collect(Collectors.toList());
+            List<String> bypassRehideBlocks = config
+                    .getList("world-settings." + worldName + ".anti-xray.bypass-rehide-blocks",
+                            config.getList("world-settings.default.anti-xray.bypass-rehide-blocks"))
+                    .stream().filter(Objects::nonNull).map(String::valueOf).collect(Collectors.toList());
             ServerLevel serverLevel = ((CraftWorld) world).getHandle();
-            ChunkPacketBlockControllerAntiXray controller = new ChunkPacketBlockControllerAntiXray(plugin, ((CraftWorld) world).getHandle().chunkPacketBlockController, rayTraceThirdPerson, rayTraceDistance, rehideBlocks, rehideDistance, maxRayTraceBlockCountPerChunk, rayTraceBlocks.isEmpty() ? null : rayTraceBlocks, serverLevel, MinecraftServer.getServer().executor);
+            ChunkPacketBlockControllerAntiXray controller = new ChunkPacketBlockControllerAntiXray(plugin,
+                    ((CraftWorld) world).getHandle().chunkPacketBlockController, rayTraceThirdPerson, rayTraceDistance,
+                    rehideBlocks, rehideDistance, maxRayTraceBlockCountPerChunk,
+                    rayTraceBlocks.isEmpty() ? null : rayTraceBlocks,
+                    bypassRehideBlocks.isEmpty() ? null : bypassRehideBlocks, serverLevel,
+                    MinecraftServer.getServer().executor);
 
             try {
                 Field field = Level.class.getDeclaredField("chunkPacketBlockController");
@@ -61,7 +82,8 @@ public final class WorldListener implements Listener {
 
     public static void handleUnload(RayTraceAntiXray plugin, World w) {
         if (((CraftWorld) w).getHandle().chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray) {
-            ChunkPacketBlockController oldController = ((ChunkPacketBlockControllerAntiXray) ((CraftWorld) w).getHandle().chunkPacketBlockController).getOldController();
+            ChunkPacketBlockController oldController = ((ChunkPacketBlockControllerAntiXray) ((CraftWorld) w)
+                    .getHandle().chunkPacketBlockController).getOldController();
 
             try {
                 Field field = Level.class.getDeclaredField("chunkPacketBlockController");

--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/tasks/RayTraceCallable.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/tasks/RayTraceCallable.java
@@ -9,6 +9,7 @@ import com.vanillage.raytraceantixray.util.BlockOcclusionCulling.BlockOcclusionG
 import io.papermc.paper.antixray.ChunkPacketBlockController;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -22,6 +23,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -37,12 +39,14 @@ public final class RayTraceCallable implements Callable<Void> {
     private final double rayTraceDistanceSquared;
     private final boolean rehideBlocks;
     private final double rehideDistanceSquared;
+    private final Set<Block> bypassRehideBlocks;
 
     private volatile VectorialLocation[] tracedLocations = null;
 
     public RayTraceCallable(RayTraceAntiXray plugin, PlayerData playerData) {
         this.plugin = plugin;
-        ChunkPacketBlockController chunkPacketBlockController = ((CraftWorld) playerData.getLocations()[0].getWorld()).getHandle().chunkPacketBlockController;
+        ChunkPacketBlockController chunkPacketBlockController = ((CraftWorld) playerData.getLocations()[0].getWorld())
+                .getHandle().chunkPacketBlockController;
 
         if (!(chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray chunkPacketBlockControllerAntiXray)) {
             this.playerData = null;
@@ -53,6 +57,7 @@ public final class RayTraceCallable implements Callable<Void> {
             rayTraceDistanceSquared = 0.;
             rehideBlocks = false;
             rehideDistanceSquared = 0.;
+            bypassRehideBlocks = null;
             return;
         }
 
@@ -95,7 +100,14 @@ public final class RayTraceCallable implements Callable<Void> {
                     }
 
                     LevelChunkSection section = chunk.getSections()[sectionY - minSectionY];
-                    return section != null && !section.hasOnlyAir() && solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE.idFor(getBlockState(section, x, y, z), null)]; // Sections aren't null anymore. Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily resets #nonEmptyBlockCount to 0 due to a Paper optimization.
+                    return section != null && !section.hasOnlyAir()
+                            && solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE
+                                    .idFor(getBlockState(section, x, y, z), null)]; // Sections aren't null anymore.
+                                                                                    // Unfortunately,
+                                                                                    // LevelChunkSection#recalcBlockCounts()
+                                                                                    // temporarily resets
+                                                                                    // #nonEmptyBlockCount to 0 due to a
+                                                                                    // Paper optimization.
                 }
 
                 int sectionY = y >> 4;
@@ -112,14 +124,22 @@ public final class RayTraceCallable implements Callable<Void> {
                     }
 
                     LevelChunkSection section = chunk.getSections()[sectionY - minSectionY];
-                    return section != null && !section.hasOnlyAir() && solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE.idFor(getBlockState(section, x, y, z), null)]; // Sections aren't null anymore. Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily resets #nonEmptyBlockCount to 0 due to a Paper optimization.
+                    return section != null && !section.hasOnlyAir()
+                            && solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE
+                                    .idFor(getBlockState(section, x, y, z), null)]; // Sections aren't null anymore.
+                                                                                    // Unfortunately,
+                                                                                    // LevelChunkSection#recalcBlockCounts()
+                                                                                    // temporarily resets
+                                                                                    // #nonEmptyBlockCount to 0 due to a
+                                                                                    // Paper optimization.
                 }
 
                 if (section == null) {
                     return chunk == null && UNLOADED_OCCLUDING;
                 }
 
-                return solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE.idFor(getBlockState(section, x, y, z), null)];
+                return solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE
+                        .idFor(getBlockState(section, x, y, z), null)];
             }
 
             @Override
@@ -161,12 +181,14 @@ public final class RayTraceCallable implements Callable<Void> {
                         return false;
                     }
 
-                    if (section.hasOnlyAir()) { // Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily resets #nonEmptyBlockCount to 0 due to a Paper optimization.
+                    if (section.hasOnlyAir()) { // Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily
+                                                // resets #nonEmptyBlockCount to 0 due to a Paper optimization.
                         section = null;
                         return false;
                     }
 
-                    return solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE.idFor(getBlockState(section, x, y, z), null)];
+                    return solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE
+                            .idFor(getBlockState(section, x, y, z), null)];
                 }
 
                 if (this.sectionY != sectionY) {
@@ -190,19 +212,22 @@ public final class RayTraceCallable implements Callable<Void> {
                         return false;
                     }
 
-                    if (section.hasOnlyAir()) { // Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily resets #nonEmptyBlockCount to 0 due to a Paper optimization.
+                    if (section.hasOnlyAir()) { // Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily
+                                                // resets #nonEmptyBlockCount to 0 due to a Paper optimization.
                         section = null;
                         return false;
                     }
 
-                    return solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE.idFor(getBlockState(section, x, y, z), null)];
+                    return solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE
+                            .idFor(getBlockState(section, x, y, z), null)];
                 }
 
                 if (section == null) {
                     return chunk == null && UNLOADED_OCCLUDING;
                 }
 
-                return solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE.idFor(getBlockState(section, x, y, z), null)];
+                return solidGlobal[ChunkPacketBlockControllerAntiXray.GLOBAL_BLOCKSTATE_PALETTE
+                        .idFor(getBlockState(section, x, y, z), null)];
             }
 
             @Override
@@ -220,13 +245,16 @@ public final class RayTraceCallable implements Callable<Void> {
                 section = null;
             }
         };
-        blockOcclusionCulling = new BlockOcclusionCulling(new BlockIterator(0., 0., 0., 0., 0., 0.)::initializeNormalized, cachedSectionBlockOcclusionGetter, true);
+        blockOcclusionCulling = new BlockOcclusionCulling(
+                new BlockIterator(0., 0., 0., 0., 0., 0.)::initializeNormalized, cachedSectionBlockOcclusionGetter,
+                true);
         this.chunks = chunks.values();
         rayTraceDistance = chunkPacketBlockControllerAntiXray.rayTraceDistance;
         rayTraceDistanceSquared = rayTraceDistance * rayTraceDistance;
         rehideBlocks = chunkPacketBlockControllerAntiXray.rehideBlocks;
         double rehideDistance = chunkPacketBlockControllerAntiXray.rehideDistance;
         rehideDistanceSquared = rehideDistance * rehideDistance;
+        bypassRehideBlocks = chunkPacketBlockControllerAntiXray.bypassRehideBlocks;
     }
 
     @Override
@@ -308,7 +336,8 @@ public final class RayTraceCallable implements Callable<Void> {
                 double differenceX = playerX - centerX;
                 double differenceY = playerY - centerY;
                 double differenceZ = playerZ - centerZ;
-                double distanceSquared = differenceX * differenceX + differenceY * differenceY + differenceZ * differenceZ;
+                double distanceSquared = differenceX * differenceX + differenceY * differenceY
+                        + differenceZ * differenceZ;
 
                 if (!(distanceSquared <= rayTraceDistanceSquared)) {
                     continue;
@@ -328,7 +357,8 @@ public final class RayTraceCallable implements Callable<Void> {
                         cachedSectionBlockOcclusionGetter.initializeCache(chunk, chunkX, sectionY, chunkZ);
 
                         if (i == 0) {
-                            if (blockOcclusionCulling.isVisible(x, y, z, centerX, centerY, centerZ, differenceX, differenceY, differenceZ, distanceSquared, directionX, directionY, directionZ)) {
+                            if (blockOcclusionCulling.isVisible(x, y, z, centerX, centerY, centerZ, differenceX,
+                                    differenceY, differenceZ, distanceSquared, directionX, directionY, directionZ)) {
                                 visible = true;
                                 break;
                             }
@@ -338,7 +368,11 @@ public final class RayTraceCallable implements Callable<Void> {
                             double vectorDifferenceY = vector.getY() - centerY;
                             double vectorDifferenceZ = vector.getZ() - centerZ;
 
-                            if (blockOcclusionCulling.isVisible(x, y, z, centerX, centerY, centerZ, vectorDifferenceX, vectorDifferenceY, vectorDifferenceZ, vectorDifferenceX * vectorDifferenceX + vectorDifferenceY * vectorDifferenceY + vectorDifferenceZ * vectorDifferenceZ, directionX, directionY, directionZ)) {
+                            if (blockOcclusionCulling.isVisible(x, y, z, centerX, centerY, centerZ, vectorDifferenceX,
+                                    vectorDifferenceY, vectorDifferenceZ,
+                                    vectorDifferenceX * vectorDifferenceX + vectorDifferenceY * vectorDifferenceY
+                                            + vectorDifferenceZ * vectorDifferenceZ,
+                                    directionX, directionY, directionZ)) {
                                 visible = true;
                                 break;
                             }
@@ -353,7 +387,22 @@ public final class RayTraceCallable implements Callable<Void> {
                         results.add(new Result(chunkBlocks, block, true));
 
                         if (rehideBlocks) {
-                            blockHidden.setValue(false);
+                            boolean bypass = false;
+
+                            if (bypassRehideBlocks != null) {
+                                LevelChunkSection section = chunk.getSections()[(y >> 4) - chunk.getMinSectionY()];
+
+                                if (section != null && !section.hasOnlyAir()
+                                        && bypassRehideBlocks.contains(getBlockState(section, x, y, z).getBlock())) {
+                                    bypass = true;
+                                }
+                            }
+
+                            if (bypass) {
+                                iterator.remove();
+                            } else {
+                                blockHidden.setValue(false);
+                            }
                         } else {
                             iterator.remove();
                         }
@@ -370,16 +419,16 @@ public final class RayTraceCallable implements Callable<Void> {
 
     private static BlockState getBlockState(LevelChunkSection section, int x, int y, int z) {
         // synchronized (section.getStates()) {
-        //     try {
-        //         section.getStates().acquire();
-                try {
-                    return section.getBlockState(x & 15, y & 15, z & 15);
-                } catch (MissingPaletteEntryException e) {
-                    return AIR;
-                }
-        //     } finally {
-        //         section.getStates().release();
-        //     }
+        // try {
+        // section.getStates().acquire();
+        try {
+            return section.getBlockState(x & 15, y & 15, z & 15);
+        } catch (MissingPaletteEntryException e) {
+            return AIR;
+        }
+        // } finally {
+        // section.getStates().release();
+        // }
         // }
     }
 

--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/tasks/RayTraceCallable.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/tasks/RayTraceCallable.java
@@ -46,8 +46,7 @@ public final class RayTraceCallable implements Callable<Void> {
 
     public RayTraceCallable(RayTraceAntiXray plugin, PlayerData playerData) {
         this.plugin = plugin;
-        ChunkPacketBlockController chunkPacketBlockController = ((CraftWorld) playerData.getLocations()[0].getWorld())
-                .getHandle().chunkPacketBlockController;
+        ChunkPacketBlockController chunkPacketBlockController = ((CraftWorld) playerData.getLocations()[0].getWorld()).getHandle().chunkPacketBlockController;
 
         if (!(chunkPacketBlockController instanceof ChunkPacketBlockControllerAntiXray chunkPacketBlockControllerAntiXray)) {
             this.playerData = null;
@@ -167,8 +166,7 @@ public final class RayTraceCallable implements Callable<Void> {
                         return false;
                     }
 
-                    if (section.hasOnlyAir()) { // Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily
-                                                // resets #nonEmptyBlockCount to 0 due to a Paper optimization.
+                    if (section.hasOnlyAir()) { // Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily resets #nonEmptyBlockCount to 0 due to a Paper optimization.
                         section = null;
                         return false;
                     }
@@ -197,8 +195,7 @@ public final class RayTraceCallable implements Callable<Void> {
                         return false;
                     }
 
-                    if (section.hasOnlyAir()) { // Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily
-                                                // resets #nonEmptyBlockCount to 0 due to a Paper optimization.
+                    if (section.hasOnlyAir()) { // Unfortunately, LevelChunkSection#recalcBlockCounts() temporarily resets #nonEmptyBlockCount to 0 due to a Paper optimization.
                         section = null;
                         return false;
                     }
@@ -228,9 +225,7 @@ public final class RayTraceCallable implements Callable<Void> {
                 section = null;
             }
         };
-        blockOcclusionCulling = new BlockOcclusionCulling(
-                new BlockIterator(0., 0., 0., 0., 0., 0.)::initializeNormalized, cachedSectionBlockOcclusionGetter,
-                true);
+        blockOcclusionCulling = new BlockOcclusionCulling(new BlockIterator(0., 0., 0., 0., 0., 0.)::initializeNormalized, cachedSectionBlockOcclusionGetter, true);
         this.chunks = chunks.values();
         rayTraceDistance = chunkPacketBlockControllerAntiXray.rayTraceDistance;
         rayTraceDistanceSquared = rayTraceDistance * rayTraceDistance;
@@ -319,8 +314,7 @@ public final class RayTraceCallable implements Callable<Void> {
                 double differenceX = playerX - centerX;
                 double differenceY = playerY - centerY;
                 double differenceZ = playerZ - centerZ;
-                double distanceSquared = differenceX * differenceX + differenceY * differenceY
-                        + differenceZ * differenceZ;
+                double distanceSquared = differenceX * differenceX + differenceY * differenceY + differenceZ * differenceZ;
 
                 if (!(distanceSquared <= rayTraceDistanceSquared)) {
                     continue;
@@ -340,8 +334,7 @@ public final class RayTraceCallable implements Callable<Void> {
                         cachedSectionBlockOcclusionGetter.initializeCache(chunk, chunkX, sectionY, chunkZ);
 
                         if (i == 0) {
-                            if (blockOcclusionCulling.isVisible(x, y, z, centerX, centerY, centerZ, differenceX,
-                                    differenceY, differenceZ, distanceSquared, directionX, directionY, directionZ)) {
+                            if (blockOcclusionCulling.isVisible(x, y, z, centerX, centerY, centerZ, differenceX, differenceY, differenceZ, distanceSquared, directionX, directionY, directionZ)) {
                                 visible = true;
                                 break;
                             }
@@ -351,11 +344,7 @@ public final class RayTraceCallable implements Callable<Void> {
                             double vectorDifferenceY = vector.getY() - centerY;
                             double vectorDifferenceZ = vector.getZ() - centerZ;
 
-                            if (blockOcclusionCulling.isVisible(x, y, z, centerX, centerY, centerZ, vectorDifferenceX,
-                                    vectorDifferenceY, vectorDifferenceZ,
-                                    vectorDifferenceX * vectorDifferenceX + vectorDifferenceY * vectorDifferenceY
-                                            + vectorDifferenceZ * vectorDifferenceZ,
-                                    directionX, directionY, directionZ)) {
+                            if (blockOcclusionCulling.isVisible(x, y, z, centerX, centerY, centerZ, vectorDifferenceX, vectorDifferenceY, vectorDifferenceZ, vectorDifferenceX * vectorDifferenceX + vectorDifferenceY * vectorDifferenceY + vectorDifferenceZ * vectorDifferenceZ, directionX, directionY, directionZ)) {
                                 visible = true;
                                 break;
                             }
@@ -402,16 +391,16 @@ public final class RayTraceCallable implements Callable<Void> {
 
     private static BlockState getBlockState(LevelChunkSection section, int x, int y, int z) {
         // synchronized (section.getStates()) {
-        // try {
-        // section.getStates().acquire();
-        try {
-            return section.getBlockState(x & 15, y & 15, z & 15);
-        } catch (MissingPaletteEntryException e) {
-            return AIR;
-        }
-        // } finally {
-        // section.getStates().release();
-        // }
+        //     try {
+        //         section.getStates().acquire();
+                try {
+                    return section.getBlockState(x & 15, y & 15, z & 15);
+                } catch (MissingPaletteEntryException e) {
+                    return AIR;
+                }
+        //     } finally {
+        //         section.getStates().release();
+        //     }
         // }
     }
 

--- a/RayTraceAntiXray/src/main/resources/config.yml
+++ b/RayTraceAntiXray/src/main/resources/config.yml
@@ -18,6 +18,7 @@
 #       ray-trace-distance: 64.0                # Blocks with a greater distance between the block center and the player eye are not calculated and will thus stay hidden or revealed depending on the previous state.
 #       rehide-blocks: true                     # Whether or not to rehide revealed blocks that the player can no longer see. If false, revealed (already seen) blocks are only rehidden when the chunk is resent.
 #       rehide-distance: 60.0                   # Blocks with a greater or equal distance between the block center and the player eye are treated as invisible to the player and are therefore (re)hidden (provided that rehide-blocks is enabled and the distance is still within the ray-trace-distance). If rehide-blocks is disabled, this setting has a similar effect as the ray-trace-distance and no effect if it is greater than the ray-trace-distance.
+#       bypass-rehide-blocks: []                # Blocks that will never rehide
 #       ### Block selection related settings ###
 #       # The following settings are used to determine the list of block positions to be hidden and ray traced when a chunk is sent to a player.
 #       # Note that this list is not updated dynamically with newly placed or broken blocks until the chunk is resent.

--- a/RayTraceAntiXray/src/main/resources/config.yml
+++ b/RayTraceAntiXray/src/main/resources/config.yml
@@ -46,4 +46,5 @@ world-settings:
       max-ray-trace-block-count-per-chunk: 100
       rehide-blocks: false
       rehide-distance: .inf
+      bypass-rehide-blocks: []
       ray-trace-blocks: []


### PR DESCRIPTION
### Description
I added a new configuration option `bypass-rehide-blocks`.
This allows server owners to specify a list of blocks that should **not** be rehidden once revealed, even if `rehide-blocks: true` is enabled globally.
### Use Case
**1. Improved Visuals for Large Structures (e.g., Trail Chambers)**
When large naturally exposed structures (like Trail Chambers with Copper blocks) are hidden using Anti-Xray, they can flicker annoyingly when `rehide-blocks` is enabled. By adding these specific blocks to the bypass list, they will be hidden until revealed, but **remain visible** afterwards. This prevents the "flickering" effect while looking around, preserving the immersive experience.
**2. Performance Optimization**
Bypassing unnecessary re-hiding for common blocks in these structures reduces the processing overhead. The server doesn't need to constantly calculate occlusion and send hide packets for blocks the player has already legitimately found and is standing near.