### PR TITLE
Fix anti-xray height calculation and prevent ore exposure above Y=64

### DIFF
--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/antixray/ChunkPacketBlockControllerAntiXray.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/antixray/ChunkPacketBlockControllerAntiXray.java
@@ -90,7 +90,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         this.executor = executor;
         WorldConfiguration.Anticheat.AntiXray paperWorldConfig = level.paperConfig().anticheat.antiXray;
         engineMode = paperWorldConfig.engineMode;
-        maxBlockHeight = paperWorldConfig.maxBlockHeight >> 4 << 4;
+        maxBlockHeight = level.getMaxY();
         updateRadius = paperWorldConfig.updateRadius;
         usePermission = paperWorldConfig.usePermission;
         this.rayTraceThirdPerson = rayTraceThirdPerson;

--- a/RayTraceAntiXray/src/main/resources/plugin.yml
+++ b/RayTraceAntiXray/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: RayTraceAntiXray
 main: com.vanillage.raytraceantixray.RayTraceAntiXray
-version: 1.17.6
+version: 1.17.7
 api-version: 1.21.11
 # Authors and contributors of the plugin
 authors:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.vanillage.raytraceantixray"
-version = "1.17.6"
+version = "1.17.7"
 description = "RayTraceAntiXray"
 java.sourceCompatibility = JavaVersion.VERSION_21
 


### PR DESCRIPTION
**Update RayTraceAntiXray to 1.17.7**

This pull request updates the **RayTraceAntiXray** plugin to version **1.17.7** and fixes a critical issue in how the maximum block height was calculated for anti-xray checks.

### The Problem

Previously, the plugin determined `maxBlockHeight` using a shifted value from the configuration. In practice, this caused the anti-xray logic to only apply correctly up to **Y=64**, as shown in the screenshot below:

<img width="2560" height="1017" alt="2026-02-15_18 54 27" src="https://github.com/user-attachments/assets/997a769e-939c-4947-ba6e-e21f29edff33" />

As a result, **all ores above Y=64 were fully visible to players**, even when Paper’s anti-xray system was supposed to hide them.

This behavior effectively bypassed the protection mechanism and could be abused.

### Impact

This issue creates significant gameplay and economy problems, especially in scenarios such as:

* **Mountain biomes** containing emerald ore veins above Y=64
* **Gold ore generation above Y=64**, which is common in certain terrain formations (such as Mesa biomes)
* Any custom world generation with ores placed above Y=64

Because the anti-xray checks were not applied above that height, players could easily locate exposed ores simply by going above Y=64.

### Solution

The calculation of `maxBlockHeight` in  
`ChunkPacketBlockControllerAntiXray.java`  
has been updated:

* **Before:** Used a shifted configuration value (originally intended for minor performance optimization)
* **Now:** Uses `level.getMaxY()`

This ensures that the anti-xray logic correctly respects the world's actual maximum height and applies protection consistently across the entire vertical range.

### Changes

**Version update**

* Updated plugin version in `plugin.yml` to **1.17.7**, as this is a patch fix rather than a new feature.

**Anti-xray configuration improvement**

* Replaced the previous height calculation with `level.getMaxY()` to ensure accurate and safe anti-xray behavior.

---

This fix restores proper anti-xray functionality across all world heights and prevents abuse related to ore visibility above Y=64.

Screenshot after this simple fix:
<img width="2560" height="1017" alt="2026-02-15_18 53 09" src="https://github.com/user-attachments/assets/49044c7d-f354-4b4c-a4fa-421c45631c0a" />
