### PR TITLE
Concurrency, error-handling fixes + tighter default config

### DIFF
--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/RayTraceAntiXray.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/RayTraceAntiXray.java
@@ -129,7 +129,11 @@ public final class RayTraceAntiXray extends JavaPlugin {
         HandlerList.unregisterAll(this);
 
         // cancel any global tasks
-        Bukkit.getScheduler().cancelTasks(this);
+        // On Folia, CraftScheduler#cancelTasks throws UnsupportedOperationException —
+        // tasks live per-region, the global region scheduler handles plugin-wide ones.
+        if (!BukkitUtil.IS_FOLIA) {
+            Bukkit.getScheduler().cancelTasks(this);
+        }
         Bukkit.getGlobalRegionScheduler().cancelTasks(this);
 
         // unhook from players

--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/antixray/ChunkPacketBlockControllerAntiXray.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/antixray/ChunkPacketBlockControllerAntiXray.java
@@ -433,6 +433,7 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         Object2BooleanMap<BlockPos> blocks = new Object2BooleanOpenHashMap<>();
         HashSet<BlockPos> blockEntities = new HashSet<>();
 
+        boolean obfuscationSucceeded = true;
         try {
         for (int chunkSectionIndex = 0; chunkSectionIndex <= maxChunkSectionIndex; chunkSectionIndex++) {
             if (chunkPacketInfoAntiXray.isWritten(chunkSectionIndex) && chunkPacketInfoAntiXray.getPresetValues(chunkSectionIndex) != null) {
@@ -589,18 +590,23 @@ public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockCo
         } catch (Exception e) {
             // Catch any unexpected exceptions during chunk obfuscation
             // This can happen with FartherViewDistance or other plugins that create chunks
+            obfuscationSucceeded = false;
             if (plugin.handleNag("controller failed obfuscate")) {
                 plugin.getLogger().log(java.util.logging.Level.WARNING, "Failed to obfuscate chunk: chunk=%s level=%s".formatted(chunk.getPos(), level), e);
                 plugin.logDebugNagReminder();
             }
-            // Fall through to set the packet as ready anyway
+            // The packet buffer may already be partially mutated. We still cache
+            // the (possibly partial) blocks list so the ray-trace pass can reveal
+            // what was collected — better than leaving obfuscated blocks
+            // permanently hidden. Block-entity removal is gated below to avoid
+            // applying a partially-collected removal set.
         }
 
         if (plugin.isRunning()) {
             plugin.getPacketChunkBlocksCache().put(chunkPacketInfoAntiXray.getChunkPacket(), new ChunkBlocks(chunkPacketInfoAntiXray.getChunk(), blocks));
         }
 
-        if (blockEntities != null && !blockEntities.isEmpty()) {
+        if (obfuscationSucceeded && blockEntities != null && !blockEntities.isEmpty()) {
             try {
                 List<?> blockEntitiesData = (List<?>) BLOCK_ENTITIES_DATA_FIELD.get(chunkPacketInfoAntiXray.getChunkPacket().getChunkData());
                 // Skip if blockEntitiesData is null or empty - may happen with FartherViewDistance chunks

--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/tasks/RayTraceTimerTask.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/tasks/RayTraceTimerTask.java
@@ -48,7 +48,9 @@ public final class RayTraceTimerTask extends TimerTask {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (RejectedExecutionException e) {
-
+            if (plugin.isRunning()) {
+                plugin.getLogger().log(Level.FINE, "Executor rejected raytrace task", e);
+            }
         } catch (Throwable t) {
             plugin.getLogger().log(Level.SEVERE, "Error thrown while raytracing: ", t);
         }

--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/tasks/UpdateBukkitRunnable.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/tasks/UpdateBukkitRunnable.java
@@ -147,6 +147,8 @@ public final class UpdateBukkitRunnable implements Consumer<ScheduledTask> {
             return false;
 
         Channel channel = connection.connection.channel;
+        if (channel == null)
+            return false;
 
         // wrap whole operation in event loop, otherwise Channel#write will do it for each packet
         channel.eventLoop().execute(() -> {

--- a/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/util/NetworkUtil.java
+++ b/RayTraceAntiXray/src/main/java/com/vanillage/raytraceantixray/util/NetworkUtil.java
@@ -13,10 +13,8 @@ import java.util.Objects;
 
 public class NetworkUtil {
 
-    private static Field field_serverGamePacketListenerImpl_connection = null;
-
-    private static Field field_regionizedServer_connections = null;
-    private static Object regionizedServerInstance = null;
+    private static volatile Field field_regionizedServer_connections = null;
+    private static volatile Object regionizedServerInstance = null;
 
     @SuppressWarnings("unchecked")
     public static Iterable<Connection> getConnections() {

--- a/RayTraceAntiXray/src/main/resources/config.yml
+++ b/RayTraceAntiXray/src/main/resources/config.yml
@@ -44,9 +44,61 @@ world-settings:
     anti-xray:
       ray-trace: true
       ray-trace-third-person: false
-      ray-trace-distance: 120.0
-      max-ray-trace-block-count-per-chunk: 100
-      rehide-blocks: false
-      rehide-distance: .inf
+      # 64 blocks is a good balance between security and CPU cost.
+      # 120 is excessive — players rarely see ores beyond ~48 blocks in normal gameplay.
+      ray-trace-distance: 64.0
+      max-ray-trace-block-count-per-chunk: 30
+      rehide-blocks: true
+      rehide-distance: 60.0
       bypass-rehide-blocks: []
+      # If this list is empty, the hidden-blocks from the Paper config (paper-world-defaults.yml) are used.
+      # Per-world sections below override this with a curated list for each dimension.
+      ray-trace-blocks: []
+
+  # Overworld — hide all valuable ores including deepslate variants (1.21)
+  world:
+    anti-xray:
+      ray-trace: true
+      ray-trace-distance: 64.0
+      rehide-blocks: true
+      rehide-distance: 60.0
+      max-ray-trace-block-count-per-chunk: 30
+      bypass-rehide-blocks: []
+      ray-trace-blocks:
+      - coal_ore
+      - deepslate_coal_ore
+      - iron_ore
+      - deepslate_iron_ore
+      - copper_ore
+      - deepslate_copper_ore
+      - gold_ore
+      - deepslate_gold_ore
+      - redstone_ore
+      - deepslate_redstone_ore
+      - emerald_ore
+      - deepslate_emerald_ore
+      - lapis_ore
+      - deepslate_lapis_ore
+      - diamond_ore
+      - deepslate_diamond_ore
+
+  # Nether — hide quartz, gold and ancient debris
+  world_nether:
+    anti-xray:
+      ray-trace: true
+      ray-trace-distance: 64.0
+      rehide-blocks: true
+      rehide-distance: 60.0
+      max-ray-trace-block-count-per-chunk: 30
+      bypass-rehide-blocks: []
+      ray-trace-blocks:
+      - nether_gold_ore
+      - nether_quartz_ore
+      - ancient_debris
+
+  # The End — no valuable ores to hide; ray tracing is disabled to save resources.
+  # Enable and populate ray-trace-blocks if you add custom ores via datapacks or mods.
+  world_the_end:
+    anti-xray:
+      ray-trace: false
       ray-trace-blocks: []


### PR DESCRIPTION
## Summary

Follow-up to #7. Two commits:

1. **Bugfix commit** — four small concurrency / error-handling fixes found during a post-merge code scan.
2. **Config commit** — tighten the default `config.yml` and pre-populate per-world ore lists.

---

## Bugfixes (`Fix concurrency, error-handling and obfuscation-fallback bugs`)

### `NetworkUtil.java`
- Marked the Folia reflection cache fields (`field_regionizedServer_connections`, `regionizedServerInstance`) as `volatile`. The previous lazy-init was a non-atomic check-then-act on plain static fields: one thread could publish `field_regionizedServer_connections` before `regionizedServerInstance`, letting another thread bypass the guard and reach `field.get(null)` — NPE.
- Removed the unused `field_serverGamePacketListenerImpl_connection` field (dead code, no readers anywhere).

### `RayTraceTimerTask.java`
- The empty `catch (RejectedExecutionException)` silently stopped ray tracing if the executor rejected a task. Now logs at `FINE` when `plugin.isRunning()`, so debugging is possible without spamming `WARNING` during normal shutdown.

### `UpdateBukkitRunnable.sendPackets`
- Added a `channel == null` guard before scheduling on the netty event loop. `connection.isConnected()` doesn't strictly imply a non-null channel reference (e.g., briefly between accept and channel attachment).

### `ChunkPacketBlockControllerAntiXray.obfuscate`
- When obfuscation throws partway, the packet buffer can be partially mutated. The previous code put a (possibly partial) `ChunkBlocks` into the packet cache and then ran the block-entity `removeIf` on a (possibly partial) `blockEntities` set — silently corrupting the BE list in the outgoing packet.
- Introduced an `obfuscationSucceeded` flag:
  - Cache `.put(...)` still runs unconditionally (when running), so the ray-trace pass can reveal whatever blocks were collected before the exception — better than leaving them permanently hidden.
  - BE removal is now gated on `obfuscationSucceeded`. On exception, the BE-removal step is skipped entirely and the packet keeps its original BE data list.

**Known limitation:** the packet buffer itself can still be partially mutated before the exception, and `setReady(true)` is still required to avoid hanging the chunk packet. A snapshot+restore of the buffer would close this window fully — left as a follow-up (low priority, only triggers with incompatible plugins like FartherViewDistance hitting the obfuscation path).

---

## Config (`Tighten default config and add per-world ore lists`)

- `ray-trace-distance: 120 → 64` — ores beyond ~48 blocks aren't normally visible; 64 keeps a small safety margin and significantly cuts per-tick raytrace cost.
- `max-ray-trace-block-count-per-chunk: 100 → 30` — further CPU savings; still covers typical ore clusters.
- `rehide-blocks: false → true`, `rehide-distance: 60` — re-hides ores the player walked past, closing the time-window where a briefly-revealed ore stays observable.
- Per-world `ray-trace-blocks` for `world` / `world_nether` / `world_the_end` with the standard 1.21 ore set (incl. deepslate variants and `ancient_debris`). Saves admins from hunting through `paper-world-defaults.yml`.

---

## Test plan

- [x] `./gradlew compileJava` on the pre-rebase commit (dev-bundle `26.1.2.build.49-beta`) — build clean
- [ ] Note: `gradlew compileJava` on current `main` fails for an unrelated reason — `dev-bundle 26.1.2.build.63-stable` references `net.kyori:adventure-text-serializer-ansi` with **no version** in its Gradle module metadata, so classpath resolution fails before the compile step runs. Not introduced by this PR.
- [ ] Manual smoke test on Folia 26.1.2 — verify ores hide / world changes don't NPE / `RejectedExecutionException` doesn't spam logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)